### PR TITLE
Feature/issue 2 symbol resolution refactor

### DIFF
--- a/example/exampleWidgetQt/CMakeLists.txt
+++ b/example/exampleWidgetQt/CMakeLists.txt
@@ -70,6 +70,8 @@ set(PROJECT_SOURCES
         ${SRC}/hope_stack.h
         ${SRC}/hope_symbol_build_pass.cpp
         ${SRC}/hope_symbol_build_pass.h
+        ${SRC}/hope_symbol_link_pass.cpp
+        ${SRC}/hope_symbol_link_pass.h
         ${SRC}/hope_unicode.h
         ${SRC}/hope_value.h
         ${GEN}/semantic_tags.h

--- a/src/hope_interpreter.cpp
+++ b/src/hope_interpreter.cpp
@@ -647,7 +647,7 @@ Value Interpreter::anonFun(ParseNode pn){
 
     ParseNode upvalues = l.upvalues(parse_tree);
 
-    Closure* list = &l.captured;
+    Closure* list = &l.closure;
 
     initClosure(*list, ParseTree::EMPTY, upvalues);
 
@@ -662,12 +662,12 @@ Value Interpreter::call(ParseNode call) {
         case Lambda_index:{
             Lambda& f = std::get<Lambda>(v);
             ParseNode params = f.params(parse_tree);
-            breakLocalClosureLinks(f.captured, ParseTree::EMPTY, f.upvalues(parse_tree));
+            breakLocalClosureLinks(f.closure, ParseTree::EMPTY, f.upvalues(parse_tree));
             size_t nparams = parse_tree.getNumArgs(params);
             if(nparams != nargs) return error(INVALID_ARGS, call);
             size_t stack_size = stack.size();
             Closure* old = active_closure;
-            active_closure = &f.captured;
+            active_closure = &f.closure;
             std::vector<std::pair<Value, std::string>> stack_vals;
             for(size_t i = 0; i < nargs && exit_mode == KEEP_GOING; i++){
                 ParseNode param = parse_tree.arg(params, i);

--- a/src/hope_interpreter.cpp
+++ b/src/hope_interpreter.cpp
@@ -1,6 +1,7 @@
 #include "hope_interpreter.h"
 
 #include <code_parsenodetype.h>
+#include "hope_symbol_link_pass.h"
 #include <typeset_line.h>
 #include <typeset_model.h>
 #include <typeset_text.h>
@@ -23,11 +24,14 @@ namespace Hope {
 
 namespace Code {
 
-Interpreter::Interpreter(const ParseTree& parse_tree, Typeset::Model* model, Typeset::View* view, Typeset::View* console)
+Interpreter::Interpreter(ParseTree& parse_tree, Typeset::Model* model, Typeset::View* view, Typeset::View* console)
     : parse_tree(parse_tree), errors(model->errors), view(view), console(console) {
 }
 
-Typeset::Model* Interpreter::interpret(ParseNode root){
+Typeset::Model* Interpreter::interpret(SymbolTable& symbol_table, ParseNode root){
+    SymbolTableLinker linker(symbol_table, parse_tree);
+    linker.link();
+
     stack.clear();
 
     output = Typeset::Model::fromSerial("");

--- a/src/hope_interpreter.h
+++ b/src/hope_interpreter.h
@@ -23,18 +23,19 @@ namespace Code {
 
 struct Error;
 class ParseTree;
+struct SymbolTable;
 
 class Interpreter{
 public:
-    Interpreter(const ParseTree& parse_tree,
+    Interpreter(ParseTree& parse_tree,
                 Typeset::Model* model,
                 Typeset::View* view,
                 Typeset::View* console);
-    Typeset::Model* interpret(ParseNode root);
+    Typeset::Model* interpret(SymbolTable& symbol_table, ParseNode root);
     void stop();
 
 private:
-    const ParseTree& parse_tree;
+    ParseTree& parse_tree;
     std::vector<Error>& errors;
 
     enum ExitMode{

--- a/src/hope_parser.cpp
+++ b/src/hope_parser.cpp
@@ -685,15 +685,17 @@ Parser::ParseNode Parser::lambda(const ParseNode& id) noexcept{
 
     Typeset::Marker left = parse_tree.getLeft(id);
 
+    ParseNode capture_list = ParseTree::EMPTY;
     ParseNode referenced_upvalues = ParseTree::EMPTY;
     ParseNode e = expression();
     if(!noErrors()) return e;
 
     Typeset::Selection sel(left, rMarkPrev());
 
-    return parse_tree.addTernary(
+    return parse_tree.addQuadary(
                 PN_LAMBDA,
                 sel,
+                capture_list,
                 referenced_upvalues,
                 parse_tree.addUnary(PN_LIST, id),
                 e

--- a/src/hope_symbol_build_pass.cpp
+++ b/src/hope_symbol_build_pass.cpp
@@ -36,112 +36,19 @@ void SymbolTableBuilder::resolveSymbols(){
         resolveStmt(parse_tree.arg(n, i));
 
     decreaseLexicalDepth();
-
-    stack_frame.clear();
-    stack_size = 0;
-    link(); //This should be in a separate pass after optimisation
-}
-
-void SymbolTableBuilder::link(size_t scope_index){
-    if(scope_index == NONE) return;
-
-    const Scope& scope = scopes[scope_index];
-
-    if(scope.closing_function != NONE){
-        closures.push_back(std::unordered_map<size_t, size_t>());
-        closure_size.push_back(0);
-    }
-
-    stack_frame.push_back(stack_size);
-
-    for(const Scope::Subscope& subscope : scope.subscopes){
-        for(const Scope::Usage& usage : subscope.usages){
-            Symbol& sym = symbols[usage.var_id];
-            ParseNode pn = usage.pn;
-
-            if(usage.type == Scope::DECLARE){
-                if(sym.is_closure_nested && !sym.is_captured){
-                    assert(sym.declaration_closure_depth <= closures.size());
-
-                    parse_tree.setType(pn, PN_READ_UPVALUE);
-                    parse_tree.setClosureIndex(pn, closure_size.back());
-                    closures.back()[usage.var_id] = closure_size.back()++;
-                }else{
-                    sym.stack_index = stack_size++;
-                }
-            }else{
-                if(sym.is_closure_nested){
-                    assert(sym.declaration_closure_depth <= closures.size());
-
-                    for(size_t i = sym.declaration_closure_depth; i < closures.size(); i++){
-                        std::unordered_map<size_t, size_t>& closure = closures[i];
-                        if(closure.find(usage.var_id) == closure.end())
-                            closure[usage.var_id] = closure_size[i]++;
-                    }
-                    parse_tree.setType(pn, PN_READ_UPVALUE);
-                    parse_tree.setClosureIndex(pn, closures.back()[usage.var_id]);
-                }else if(sym.declaration_closure_depth == 0){
-                    parse_tree.setType(pn, PN_READ_GLOBAL);
-                    parse_tree.setGlobalIndex(pn, sym.stack_index);
-                }else{
-                    parse_tree.setStackOffset(pn, stack_size - 1 - sym.stack_index);
-                }
-            }
-        }
-
-        link(subscope.subscope_id);
-    }
-
-    if(scope.closing_function != NONE){
-        ParseNode fn = scope.closing_function;
-
-        ParseTree::NaryBuilder upvalue_builder = parse_tree.naryBuilder(PN_LIST);
-        for(const auto& entry : closures.back()){
-            size_t symbol_index = entry.first;
-            const Symbol& sym = symbols[symbol_index];
-            ParseNode n = parse_tree.addTerminal(PN_IDENTIFIER, sym.document_occurences->front());
-
-            parse_tree.setFlag(n, entry.second);
-
-            if(sym.declaration_closure_depth != closures.size())
-                parse_tree.setType(n, PN_READ_UPVALUE);
-
-            upvalue_builder.addNaryChild(n);
-        }
-
-        ParseNode upvalue_list = upvalue_builder.finalize(parse_tree.getSelection(fn));
-
-        switch (parse_tree.getType(fn)) {
-            case PN_ALGORITHM:
-                parse_tree.setArg(fn, 2, upvalue_list);
-                break;
-            case PN_LAMBDA:
-                parse_tree.setArg(fn, 0, upvalue_list);
-                break;
-        }
-
-        closures.pop_back();
-        closure_size.pop_back();
-    }
-
-    stack_size = stack_frame.back();
-    stack_frame.pop_back();
 }
 
 void SymbolTableBuilder::reset() noexcept{
     ids.clear();
     map.clear();
     doc_map.clear();
-    scopes.clear();
-    symbols.clear();
+    symbol_table.scopes.clear();
+    symbol_table.symbols.clear();
     symbol_id_index.clear();
     lexical_depth = GLOBAL_DEPTH;
     closure_depth = 0;
-    assert(closures.size() == 0);
-    scopes.push_back(Scope(NONE, NONE));
+    symbol_table.scopes.push_back(Scope(NONE, NONE));
     active_scope_id = 0;
-    stack_size = 0;
-    stack_frame.clear();
 }
 
 void SymbolTableBuilder::resolveStmt(ParseNode pn){
@@ -228,7 +135,7 @@ void SymbolTableBuilder::resolveAssignmentId(ParseNode pn){
         makeEntry(c, id, false);
     }else{
         size_t sym_index = lastSymbolIndexOfId(lookup->second);
-        Symbol& sym = symbols[sym_index];
+        Symbol& sym = symbol_table.symbols[sym_index];
         sym.is_reassigned = true;
         parse_tree.setType(pn, PN_REASSIGN);
         resolveReference(id, c, sym_index);
@@ -246,7 +153,7 @@ void SymbolTableBuilder::resolveAssignmentSubscript(ParseNode pn, ParseNode lhs,
 
     size_t symbol_index = symbolIndexFromSelection(c);
     if(symbol_index != NONE){
-        symbols[symbol_index].is_reassigned = true;
+        symbol_table.symbols[symbol_index].is_reassigned = true;
         resolveReference(id, c, symbol_index);
     }else{
         errors.push_back(Error(c, BAD_READ));
@@ -276,7 +183,7 @@ void SymbolTableBuilder::resolveAssignmentSubscript(ParseNode pn, ParseNode lhs,
 
         parse_tree.setType(pn, PN_ELEMENTWISE_ASSIGNMENT);
         increaseLexicalDepth();
-        size_t vars_start = symbols.size();
+        size_t vars_start = symbol_table.symbols.size();
         for(ParseNode pn : undefined_vars){
             bool success = defineLocalScope(pn, false);
             assert(success);
@@ -284,7 +191,7 @@ void SymbolTableBuilder::resolveAssignmentSubscript(ParseNode pn, ParseNode lhs,
         resolveExpr(rhs);
 
         for(size_t i = 0; i < undefined_vars.size(); i++){
-            Symbol& sym = symbols[vars_start + i];
+            Symbol& sym = symbol_table.symbols[vars_start + i];
             ParseNode var = undefined_vars[undefined_vars.size()-1];
             sym.is_ewise_index = true;
             if(!sym.is_used){
@@ -345,7 +252,7 @@ void SymbolTableBuilder::resolveReference(ParseNode pn){
 
 void SymbolTableBuilder::resolveReference(ParseNode pn, const Typeset::Selection& c, size_t sym_id){
     assert(parse_tree.getType(pn) == PN_IDENTIFIER);
-    Symbol& sym = symbols[sym_id];
+    Symbol& sym = symbol_table.symbols[sym_id];
     sym.is_used = true;
 
     sym.document_occurences->push_back(c);
@@ -456,12 +363,12 @@ void SymbolTableBuilder::resolveAlgorithm(ParseNode pn){
         for(size_t i = 0; i < N; i++){
             ParseNode capture = parse_tree.arg(captured, i);
             defineLocalScope(capture, false);
-            symbols.back().is_captured = true;
-            symbols.back().is_closure_nested = true;
+            symbol_table.symbols.back().is_captured = true;
+            symbol_table.symbols.back().is_closure_nested = true;
         }
     }
 
-    size_t params_start = symbols.size();
+    size_t params_start = symbol_table.symbols.size();
     for(size_t i = 0; i < parse_tree.getNumArgs(params); i++){
         ParseNode param = parse_tree.arg(params, i);
         if(parse_tree.getType(param) == PN_EQUAL){
@@ -482,7 +389,7 @@ void SymbolTableBuilder::resolveAlgorithm(ParseNode pn){
             errors.push_back(Error(parse_tree.getSelection(n), EXPECT_DEFAULT_ARG));
         }
 
-        Symbol& sym = symbols[params_start + i];
+        Symbol& sym = symbol_table.symbols[params_start + i];
         sym.is_const = !sym.is_reassigned;
     }
 
@@ -576,7 +483,7 @@ void SymbolTableBuilder::decreaseLexicalDepth(){
             size_t sym_id = usage.var_id;
 
             Id& id = ids[symbol_id_index[sym_id]];
-            Symbol& sym = symbols[sym_id];
+            Symbol& sym = symbol_table.symbols[sym_id];
             assert(sym.declaration_lexical_depth == lexical_depth);
 
             finalize(sym);
@@ -633,18 +540,18 @@ void SymbolTableBuilder::makeEntry(const Typeset::Selection& c, ParseNode pn, bo
     assert(map.find(c) == map.end());
     size_t index = ids.size();
     symbol_id_index.push_back(ids.size());
-    ids.push_back(Id({symbols.size()}));
-    activeScope().subscopes.back().usages.push_back(Scope::Usage(symbols.size(), pn, Scope::DECLARE));
-    symbols.push_back(Symbol(c, lexical_depth, closure_depth, immutable));
+    ids.push_back(Id({symbol_table.symbols.size()}));
+    activeScope().subscopes.back().usages.push_back(Scope::Usage(symbol_table.symbols.size(), pn, Scope::DECLARE));
+    symbol_table.symbols.push_back(Symbol(c, lexical_depth, closure_depth, immutable));
     map[c] = index;
 }
 
 void SymbolTableBuilder::appendEntry(size_t index, const Typeset::Selection& c, ParseNode pn, bool immutable){
     symbol_id_index.push_back(index);
     Id& id_info = ids[index];
-    id_info.push_back(symbols.size());
-    activeScope().subscopes.back().usages.push_back(Scope::Usage(symbols.size(), pn, Scope::DECLARE));
-    symbols.push_back(Symbol(c, lexical_depth, closure_depth, immutable));
+    id_info.push_back(symbol_table.symbols.size());
+    activeScope().subscopes.back().usages.push_back(Scope::Usage(symbol_table.symbols.size(), pn, Scope::DECLARE));
+    symbol_table.symbols.push_back(Symbol(c, lexical_depth, closure_depth, immutable));
 }
 
 }

--- a/src/hope_symbol_link_pass.cpp
+++ b/src/hope_symbol_link_pass.cpp
@@ -9,7 +9,7 @@ Hope::Code::SymbolTableLinker::SymbolTableLinker(SymbolTable& symbol_table, Hope
 
 void SymbolTableLinker::link(){
     reset();
-    link(0); //This should be in a separate pass after optimisation
+    link(0);
 }
 
 void SymbolTableLinker::reset() noexcept{
@@ -92,7 +92,7 @@ void SymbolTableLinker::link(size_t scope_index){
                 parse_tree.setArg(fn, 2, upvalue_list);
                 break;
             case PN_LAMBDA:
-                parse_tree.setArg(fn, 0, upvalue_list);
+                parse_tree.setArg(fn, 1, upvalue_list);
                 break;
         }
 

--- a/src/hope_symbol_link_pass.cpp
+++ b/src/hope_symbol_link_pass.cpp
@@ -1,0 +1,109 @@
+#include "hope_symbol_link_pass.h"
+
+namespace Hope {
+
+namespace Code {
+
+Hope::Code::SymbolTableLinker::SymbolTableLinker(SymbolTable& symbol_table, Hope::Code::ParseTree& parse_tree) noexcept
+    : symbol_table(symbol_table), parse_tree(parse_tree) {}
+
+void SymbolTableLinker::link(){
+    reset();
+    link(0); //This should be in a separate pass after optimisation
+}
+
+void SymbolTableLinker::reset() noexcept{
+    assert(closures.size() == 0);
+    stack_size = 0;
+    stack_frame.clear();
+}
+
+void SymbolTableLinker::link(size_t scope_index){
+    if(scope_index == NONE) return;
+
+    const Scope& scope = symbol_table.scopes[scope_index];
+
+    if(scope.closing_function != NONE){
+        closures.push_back(std::unordered_map<size_t, size_t>());
+        closure_size.push_back(0);
+    }
+
+    stack_frame.push_back(stack_size);
+
+    for(const Scope::Subscope& subscope : scope.subscopes){
+        for(const Scope::Usage& usage : subscope.usages){
+            Symbol& sym = symbol_table.symbols[usage.var_id];
+            ParseNode pn = usage.pn;
+
+            if(usage.type == Scope::DECLARE){
+                if(sym.is_closure_nested && !sym.is_captured){
+                    assert(sym.declaration_closure_depth <= closures.size());
+
+                    parse_tree.setType(pn, PN_READ_UPVALUE);
+                    parse_tree.setClosureIndex(pn, closure_size.back());
+                    closures.back()[usage.var_id] = closure_size.back()++;
+                }else{
+                    sym.stack_index = stack_size++;
+                }
+            }else{
+                if(sym.is_closure_nested){
+                    assert(sym.declaration_closure_depth <= closures.size());
+
+                    for(size_t i = sym.declaration_closure_depth; i < closures.size(); i++){
+                        std::unordered_map<size_t, size_t>& closure = closures[i];
+                        if(closure.find(usage.var_id) == closure.end())
+                            closure[usage.var_id] = closure_size[i]++;
+                    }
+                    parse_tree.setType(pn, PN_READ_UPVALUE);
+                    parse_tree.setClosureIndex(pn, closures.back()[usage.var_id]);
+                }else if(sym.declaration_closure_depth == 0){
+                    parse_tree.setType(pn, PN_READ_GLOBAL);
+                    parse_tree.setGlobalIndex(pn, sym.stack_index);
+                }else{
+                    parse_tree.setStackOffset(pn, stack_size - 1 - sym.stack_index);
+                }
+            }
+        }
+
+        link(subscope.subscope_id);
+    }
+
+    if(scope.closing_function != NONE){
+        ParseNode fn = scope.closing_function;
+
+        ParseTree::NaryBuilder upvalue_builder = parse_tree.naryBuilder(PN_LIST);
+        for(const auto& entry : closures.back()){
+            size_t symbol_index = entry.first;
+            const Symbol& sym = symbol_table.symbols[symbol_index];
+            ParseNode n = parse_tree.addTerminal(PN_IDENTIFIER, sym.document_occurences->front());
+
+            parse_tree.setFlag(n, entry.second);
+
+            if(sym.declaration_closure_depth != closures.size())
+                parse_tree.setType(n, PN_READ_UPVALUE);
+
+            upvalue_builder.addNaryChild(n);
+        }
+
+        ParseNode upvalue_list = upvalue_builder.finalize(parse_tree.getSelection(fn));
+
+        switch (parse_tree.getType(fn)) {
+            case PN_ALGORITHM:
+                parse_tree.setArg(fn, 2, upvalue_list);
+                break;
+            case PN_LAMBDA:
+                parse_tree.setArg(fn, 0, upvalue_list);
+                break;
+        }
+
+        closures.pop_back();
+        closure_size.pop_back();
+    }
+
+    stack_size = stack_frame.back();
+    stack_frame.pop_back();
+}
+
+}
+
+}

--- a/src/hope_symbol_link_pass.h
+++ b/src/hope_symbol_link_pass.h
@@ -1,0 +1,32 @@
+#ifndef HOPE_SYMBOL_LINK_PASS_H
+#define HOPE_SYMBOL_LINK_PASS_H
+
+#include <hope_symbol_build_pass.h>
+
+namespace Hope {
+
+namespace Code {
+
+class SymbolTableLinker{
+private:
+    SymbolTable& symbol_table;
+    ParseTree& parse_tree;
+    std::vector<std::unordered_map<size_t, size_t>> closures;
+    std::vector<size_t> closure_size;
+    std::vector<size_t> stack_frame;
+    size_t stack_size;
+
+public:
+    SymbolTableLinker(SymbolTable& symbol_table, ParseTree& parse_tree) noexcept;
+    void link(); //I don't believe user errors are possible
+
+private:
+    void reset() noexcept;
+    void link(size_t scope_index);
+};
+
+}
+
+}
+
+#endif // HOPE_SYMBOL_LINK_PASS_H

--- a/src/hope_value.h
+++ b/src/hope_value.h
@@ -16,16 +16,19 @@ namespace Code {
 typedef std::vector<std::shared_ptr<void>> Closure;
 
 struct Lambda{
-    Closure captured;
+    Closure closure;
     ParseNode def;
-    ParseNode upvalues(const ParseTree& parse_tree) const noexcept{
+    ParseNode captured(const ParseTree& parse_tree) const noexcept{
         return parse_tree.arg(def, 0);
     }
-    ParseNode params(const ParseTree& parse_tree) const noexcept{
+    ParseNode upvalues(const ParseTree& parse_tree) const noexcept{
         return parse_tree.arg(def, 1);
     }
-    ParseNode expr(const ParseTree& parse_tree) const noexcept{
+    ParseNode params(const ParseTree& parse_tree) const noexcept{
         return parse_tree.arg(def, 2);
+    }
+    ParseNode expr(const ParseTree& parse_tree) const noexcept{
+        return parse_tree.arg(def, 3);
     }
 
     Lambda(ParseNode def)

--- a/src/typeset_model.cpp
+++ b/src/typeset_model.cpp
@@ -14,6 +14,7 @@
 #include <hope_scanner.h>
 #include <hope_parser.h>
 #include <hope_symbol_build_pass.h>
+#include <hope_symbol_link_pass.h>
 #include <hope_interpreter.h>
 #include <unordered_set>
 
@@ -75,8 +76,9 @@ Model* Model::run(View* caller, View* console){
         if(console) console->setModel(result);
         return result;
     }
+
     interpreter = new Code::Interpreter(parser.parse_tree, this, caller, console);
-    Model* result = interpreter->interpret(root);
+    Model* result = interpreter->interpret(symbol_builder.symbol_table, root);
     result->calculateSizes();
     result->updateLayout();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,8 @@ add_executable(HopeTests ${TEST}/test_driver.cpp
     ${SRC}/hope_stack.h
     ${SRC}/hope_symbol_build_pass.cpp
     ${SRC}/hope_symbol_build_pass.h
+    ${SRC}/hope_symbol_link_pass.cpp
+    ${SRC}/hope_symbol_link_pass.h
     ${SRC}/hope_unicode.h
     ${GEN}/semantic_tags.h
     ${INCLUDE}/typeset_command.h

--- a/test/hope_benchmark.h
+++ b/test/hope_benchmark.h
@@ -69,7 +69,7 @@ void runBenchmark(){
 
     startClock();
     for(size_t i = 0; i < ITER_INTERPRETER; i++){
-        interpreter.interpret(root);
+        interpreter.interpret(sym_table.symbol_table, root);
     }
     report("Interpreter", ITER_INTERPRETER);
 
@@ -79,7 +79,7 @@ void runBenchmark(){
 
     startClock();
     for(size_t i = 0; i < ITER_INTERPRETER; i++){
-        interpreter2.interpret(root);
+        interpreter2.interpret(sym_table.symbol_table, root);
         view.setModel(new Typeset::Model);
     }
     report("Interpret w/ view", ITER_INTERPRETER);


### PR DESCRIPTION
The symbol linking pass has been extracted from the symbol table build pass. It is now a pre-run step in the interpreter, which is appropriate since it is dealing with implementation details of the interpreter which wouldn't necessarily exist with other execution options, e.g. C++ codegen.