### PR TITLE
Feature/issue 12 text layout glitches

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ This project aims to be financially maintainable while ultimately resulting in a
 
 Feel free to report any bugs in the issue tracker and message me about feature requests or general design discussion. Tests are run automatically and required to pass before merging to main.
 
-[![C++ Integration Tests](https://github.com/JohnDTill/Forscape/actions/workflows/cpp_integration_tests.yml/badge.svg?event=push)](https://github.com/JohnDTill/Forscape/actions/workflows/run_tests.yml)
+[![C++ Integration Tests](https://github.com/JohnDTill/Forscape/actions/workflows/cpp_integration_tests.yml/badge.svg?event=push)](https://github.com/JohnDTill/Forscape/actions/workflows/cpp_integration_tests.yml)
 
-[![Qt Integration Tests](https://github.com/JohnDTill/Forscape/actions/workflows/qt_integration_tests.yml/badge.svg?event=push)](https://github.com/JohnDTill/Forscape/actions/workflows/run_tests.yml)
+[![Qt Integration Tests](https://github.com/JohnDTill/Forscape/actions/workflows/qt_integration_tests.yml/badge.svg?event=push)](https://github.com/JohnDTill/Forscape/actions/workflows/qt_integration_tests.yml)

--- a/include/typeset_view.h
+++ b/include/typeset_view.h
@@ -77,8 +77,8 @@ private:
     double yOrigin() const;
     double getLineboxWidth() const noexcept;
 
-    static constexpr double ZOOM_DEFAULT = 2;
-    static constexpr double ZOOM_MAX = 5; static_assert(ZOOM_DEFAULT <= ZOOM_MAX);
+    static constexpr double ZOOM_DEFAULT = 2.0;
+    static constexpr double ZOOM_MAX = 5.0; static_assert(ZOOM_DEFAULT <= ZOOM_MAX);
     static constexpr double ZOOM_MIN = 0.75; static_assert(ZOOM_DEFAULT >= ZOOM_MIN);
     static constexpr double ZOOM_DELTA = 1.1; static_assert(ZOOM_DELTA > 1);
     static constexpr size_t CURSOR_BLINK_INTERVAL = 600;

--- a/src/typeset_painter_qt.cpp
+++ b/src/typeset_painter_qt.cpp
@@ -39,11 +39,11 @@ static QColor getColor(SemanticType type){
 }
 
 static double getWidth(const QFont& font, const std::string& text){
-    return QFontMetrics(font).horizontalAdvance( QString::fromStdString(text) );
+    return QFontMetricsF(font).horizontalAdvance( QString::fromStdString(text) );
 }
 
 static double getWidth(const QFont& font, char ch){
-    return QFontMetrics(font).horizontalAdvance(ch);
+    return QFontMetricsF(font).horizontalAdvance(ch);
 }
 
 double getWidth(SemanticType type, uint8_t depth, const std::string& text){
@@ -246,7 +246,7 @@ void Painter::drawDot(double x, double y){
 
 double Painter::getWidth(const std::string& text){
     assert(painter.font().kerning() == false);
-    return painter.fontMetrics().horizontalAdvance( QString::fromStdString(text) );
+    return QFontMetricsF(painter.font()).horizontalAdvance( QString::fromStdString(text) );
 }
 
 void Painter::drawLineNumber(double y, size_t num, bool active){
@@ -254,10 +254,10 @@ void Painter::drawLineNumber(double y, size_t num, bool active){
     else painter.setPen(View::line_num_passive_color);
 
     painter.setFont(QFontDatabase().font("CMU Bright", "Roman", 8));
-    QFontMetrics fm = painter.fontMetrics();
+    QFontMetricsF fm (painter.font());
     QString str = QString::number(num);
     qreal x = x_offset - fm.horizontalAdvance(str);
-    y += painter.fontMetrics().descent()/2;
+    y += painter.fontMetrics().descent() / 2;
     painter.drawText(x, y, str);
 }
 
@@ -268,7 +268,7 @@ void Painter::setSelectionMode(){
 void Painter::drawSymbol(char ch, double x, double y, double w, double h){
     x += x_offset;
 
-    double scale_x = w / painter.fontMetrics().horizontalAdvance(ch);
+    double scale_x = w / QFontMetricsF(painter.font()).horizontalAdvance(ch);
     double scale_y = h / painter.fontMetrics().ascent();
     x /= scale_x;
     y = (y + h - painter.fontMetrics().descent()) / scale_y;
@@ -283,7 +283,7 @@ void Painter::drawSymbol(const std::string& str, double x, double y, double w, d
     x += x_offset;
 
     QString qstr = QString::fromStdString(str);
-    double scale_x = w / painter.fontMetrics().horizontalAdvance(qstr);
+    double scale_x = w / QFontMetricsF(painter.font()).horizontalAdvance(qstr);
     double scale_y = h / painter.fontMetrics().ascent();
     x /= scale_x;
     y = (y + h - painter.fontMetrics().descent()) / scale_y;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-set(TEST_QT ON)
+option(TEST_QT OFF)
 
 project(HopeTests LANGUAGES CXX)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-option(TEST_QT OFF)
+set(TEST_QT ON)
 
 project(HopeTests LANGUAGES CXX)
 

--- a/test/typeset_graphics.h
+++ b/test/typeset_graphics.h
@@ -41,14 +41,6 @@ inline bool testTypesetGraphics(){
         passing = false;
     }
 
-    if(passing){
-        report("Typeset QPainter", passing);
-    }else{
-        std::cout << "-- Typeset graphics: KNOWN BUG (https://github.com/JohnDTill/Forscape/issues/12)" << std::endl;
-    }
-
-    return true;
-
-    //report("Typeset graphics", passing);
-    //return passing;
+    report("Typeset graphics", passing);
+    return passing;
 }

--- a/test/typeset_qpainter.h
+++ b/test/typeset_qpainter.h
@@ -64,7 +64,7 @@ static double failRatio(const QImage& im){
 }
 
 inline bool testTypesetQPainter(){
-    constexpr double threshold = 1e-4;
+    constexpr double threshold = 5e-4; //Ideally this could be tighter
     constexpr size_t MAX_MOVES = 15;
     bool passing = true;
 

--- a/test/typeset_qpainter.h
+++ b/test/typeset_qpainter.h
@@ -64,7 +64,7 @@ static double failRatio(const QImage& im){
 }
 
 inline bool testTypesetQPainter(){
-    constexpr double threshold = 1e-12;
+    constexpr double threshold = 1e-4;
     constexpr size_t MAX_MOVES = 15;
     bool passing = true;
 
@@ -149,14 +149,6 @@ inline bool testTypesetQPainter(){
         if(num_moves > MAX_MOVES) break;
     }
 
-    if(passing){
-        report("Typeset QPainter", passing);
-    }else{
-        std::cout << "-- Typeset QPainter: KNOWN BUG (https://github.com/JohnDTill/Forscape/issues/12)" << std::endl;
-    }
-
-    return true;
-
-    //report("Typeset QPainter", passing);
-    //return passing;
+    report("Typeset QPainter", passing);
+    return passing;
 }


### PR DESCRIPTION
Using QFontMetricsF instead of QFontMetrics for the width calculations mostly alleviates the text layout problems in https://github.com/JohnDTill/Forscape/issues/12.