### PR TITLE
Fix reverse selection flickering

### DIFF
--- a/src/typeset_controller.cpp
+++ b/src/typeset_controller.cpp
@@ -259,7 +259,7 @@ bool Controller::contains(double x, double y) const{
 }
 
 void Controller::paintSelection(Painter& painter) const{
-    selection().paintSelection(painter);
+    selection().paintSelection(painter, isForward());
 }
 
 void Controller::paintCursor(Painter& painter) const {

--- a/src/typeset_painter.h
+++ b/src/typeset_painter.h
@@ -32,7 +32,7 @@ public:
     void setType(SemanticType type);
     void setScriptLevel(uint8_t depth);
     void setOffset(double x, double y);
-    void drawText(double x, double y, const std::string& text);
+    void drawText(double x, double y, const std::string& text, bool forward = true);
     void drawText(double x, double y, char ch);
     void drawSymbol(double x, double y, const std::string& text);
     void drawLine(double x, double y, double w, double h);

--- a/src/typeset_painter_qt.cpp
+++ b/src/typeset_painter_qt.cpp
@@ -104,10 +104,20 @@ void Painter::setOffset(double x, double y){
     x_offset = x;
 }
 
-void Painter::drawText(double x, double y, const std::string& text){
+void Painter::drawText(double x, double y, const std::string& text, bool forward){
     x += x_offset;
-    y += painter.fontMetrics().capHeight();
-    painter.drawText(x, y, QString::fromStdString(text));
+    QString q_str = QString::fromStdString(text);
+
+    if(forward){
+        y += painter.fontMetrics().capHeight();
+        painter.drawText(x, y, q_str);
+    }else{
+        y += painter.fontMetrics().capHeight();
+        y -= painter.fontMetrics().ascent();
+        double h = painter.fontMetrics().height();
+        double w = QFontMetricsF(painter.font()).horizontalAdvance(q_str);
+        painter.drawText(QRectF(x, y, w, h), Qt::AlignRight|Qt::AlignBaseline, q_str);
+    }
 }
 
 void Painter::drawSymbol(double x, double y, const std::string& text){

--- a/src/typeset_phrase.cpp
+++ b/src/typeset_phrase.cpp
@@ -287,59 +287,59 @@ void Phrase::updateLayout() noexcept{
     }
 }
 
-void Phrase::paint(Painter& painter) const{
+void Phrase::paint(Painter& painter, bool forward) const{
     #ifdef HOPE_TYPESET_LAYOUT_DEBUG
     painter.drawDebugPhrase(x, y, width, above_center, under_center);
     #endif
 
     painter.setScriptLevel(script_level);
-    texts.front()->paint(painter);
+    texts.front()->paint(painter, forward);
     for(size_t i = 0; i < constructs.size(); i++){
         constructs[i]->paint(painter);
         painter.setScriptLevel(script_level);
-        texts[i+1]->paint(painter);
+        texts[i+1]->paint(painter, forward);
     }
 }
 
-void Phrase::paintUntil(Painter& painter, Text* t_end, size_t index) const{
+void Phrase::paintUntil(Painter& painter, Text* t_end, size_t index, bool forward) const{
     assert(t_end->id < texts.size() && text(t_end->id) == t_end);
 
     for(size_t i = 0; i < t_end->id; i++){
         painter.setScriptLevel(script_level);
-        texts[i]->paint(painter);
+        texts[i]->paint(painter, forward);
         constructs[i]->paint(painter);
     }
 
     painter.setScriptLevel(script_level);
-    t_end->paintUntil(painter, index);
+    t_end->paintUntil(painter, index, forward);
 }
 
-void Phrase::paintAfter(Painter& painter, Text* t_start, size_t index) const{
+void Phrase::paintAfter(Painter& painter, Text* t_start, size_t index, bool forward) const{
     assert(t_start->id < texts.size() && text(t_start->id) == t_start);
 
     painter.setScriptLevel(script_level);
-    t_start->paintAfter(painter, index);
+    t_start->paintAfter(painter, index, forward);
 
     for(size_t i = t_start->id; i < constructs.size(); i++){
         constructs[i]->paint(painter);
         painter.setScriptLevel(script_level);
-        texts[i+1]->paint(painter);
+        texts[i+1]->paint(painter, forward);
     }
 }
 
-void Phrase::paintMid(Painter& painter, Text* tL, size_t iL, Text* tR, size_t iR) const{
+void Phrase::paintMid(Painter& painter, Text* tL, size_t iL, Text* tR, size_t iR, bool forward) const{
     painter.setScriptLevel(script_level);
-    tL->paintAfter(painter, iL);
+    tL->paintAfter(painter, iL, forward);
     constructs[tL->id]->paint(painter);
 
     for(size_t i = tL->id+1; i < tR->id; i++){
         painter.setScriptLevel(script_level);
-        texts[i]->paint(painter);
+        texts[i]->paint(painter, forward);
         constructs[i]->paint(painter);
     }
 
     painter.setScriptLevel(script_level);
-    tR->paintUntil(painter, iR);
+    tR->paintUntil(painter, iR, forward);
 }
 
 bool Phrase::contains(double x_test, double y_test) const noexcept{

--- a/src/typeset_phrase.h
+++ b/src/typeset_phrase.h
@@ -68,10 +68,10 @@ public:
     void updateSize() noexcept;
     void updateLayout() noexcept;
     virtual void resize() noexcept = 0;
-    virtual void paint(Painter& painter) const;
-    virtual void paintUntil(Painter& painter, Text* t_end, size_t index) const;
-    virtual void paintAfter(Painter& painter, Text* t_start, size_t index) const;
-    virtual void paintMid(Painter& painter, Text* tL, size_t iL, Text* tR, size_t iR) const;
+    virtual void paint(Painter& painter, bool forward = true) const;
+    virtual void paintUntil(Painter& painter, Text* t_end, size_t index, bool forward = true) const;
+    virtual void paintAfter(Painter& painter, Text* t_start, size_t index, bool forward = true) const;
+    virtual void paintMid(Painter& painter, Text* tL, size_t iL, Text* tR, size_t iR, bool forward = true) const;
     bool contains(double x_test, double y_test) const noexcept;
     bool containsY(double y_test) const noexcept;
     double width;

--- a/src/typeset_selection.cpp
+++ b/src/typeset_selection.cpp
@@ -510,57 +510,77 @@ void Selection::paint(Painter& painter) const{
     }
 }
 
-void Selection::paintSelectionText(Painter& painter) const{
+void Selection::paintSelectionText(Painter& painter, bool forward) const{
     if(iL!=iR){
-        double x = tR->xGlobal(iL);
         double y = tR->y;
-        double w = tR->xGlobal(iR) - x;
         double h = tR->height();
 
-        painter.drawSelection(x, y, w, h);
-        tR->paintMid(painter, iL, iR);
+        if(forward){
+            double x = tR->xGlobal(iL);
+            double w = tR->xGlobal(iR) - x;
+            painter.drawSelection(x, y, w, h);
+        }else{
+            int x = tR->xGlobal(iL);
+            int xEnd = tR->xGlobal(iR);
+            painter.drawSelection(x, y, xEnd-x, h);
+        }
+
+        tR->paintMid(painter, iL, iR, forward);
     }
 }
 
-void Selection::paintSelectionPhrase(Painter& painter) const{
-    double x = tL->xGlobal(iL);
+void Selection::paintSelectionPhrase(Painter& painter, bool forward) const{
     double y = phrase()->y;
-    double w = tR->xGlobal(iR) - x;
     double h = phrase()->height();
 
-    painter.drawSelection(x, y, w, h);
-    phrase()->paintMid(painter, tL, iL, tR, iR);
+    if(forward){
+        double x = tL->xGlobal(iL);
+        double w = tR->xGlobal(iR) - x;
+        painter.drawSelection(x, y, w, h);
+    }else{
+        int x = tL->xGlobal(iL);
+        int xEnd = tR->xGlobal(iR);
+        painter.drawSelection(x, y, xEnd-x, h);
+    }
+    phrase()->paintMid(painter, tL, iL, tR, iR, forward);
 }
 
-void Selection::paintSelectionLines(Painter& painter) const {
-    double x = tL->x + tL->xLocal(iL);
+void Selection::paintSelectionLines(Painter& painter, bool forward) const {
     double y = lL->y;
-    double w = lL->width - tL->xPhrase(iL) + NEWLINE_EXTRA;
     double h = lL->height();
-    painter.drawSelection(x, y, w, h);
-    lL->paintAfter(painter, tL, iL);
+
+    if(forward){
+        double x = tL->x + tL->xLocal(iL);
+        double w = lL->width - tL->xPhrase(iL) + NEWLINE_EXTRA;
+        painter.drawSelection(x, y, w, h);
+    }else{
+        int x = tL->x + tL->xLocal(iL);
+        int xEnd = lL->x + lL->width + NEWLINE_EXTRA;
+        painter.drawSelection(x, y, xEnd-x, h);
+    }
+    lL->paintAfter(painter, tL, iL, forward);
 
     for(Line* l = lL->nextAsserted(); l != lR; l = l->nextAsserted()){
         painter.drawSelection(l->x, l->y, l->width + NEWLINE_EXTRA, l->height());
-        l->paint(painter);
+        l->paint(painter, forward);
     }
 
     if(iR == 0 && tR == lR->front()) return;
 
-    x = lR->x;
+    double x = lR->x;
     y = lR->y;
-    w = tR->xGlobal(iR) - x;
+    double w = tR->xGlobal(iR) - x;
     h = lR->height();
     painter.drawSelection(x, y, w, h);
-    lR->paintUntil(painter, tR, iR);
+    lR->paintUntil(painter, tR, iR, forward);
 }
 
-void Selection::paintSelection(Painter& painter) const{
+void Selection::paintSelection(Painter& painter, bool forward) const{
     painter.setSelectionMode();
 
-    if(isTextSelection()) paintSelectionText(painter);
-    else if(isPhraseSelection()) paintSelectionPhrase(painter);
-    else paintSelectionLines(painter);
+    if(isTextSelection()) paintSelectionText(painter, forward);
+    else if(isPhraseSelection()) paintSelectionPhrase(painter, forward);
+    else paintSelectionLines(painter, forward);
 }
 
 void Selection::paintError(Painter& painter) const{

--- a/src/typeset_selection.h
+++ b/src/typeset_selection.h
@@ -57,10 +57,10 @@ public:
     bool containsLine(double x, double y) const noexcept;
     bool containsLine(double x, double y, Text* tL, size_t iL, Text* tR, size_t iR) const noexcept;
     void paint(Painter& painter) const;
-    void paintSelectionText(Painter& painter) const;
-    void paintSelectionPhrase(Painter& painter) const;
-    void paintSelectionLines(Painter& painter) const;
-    void paintSelection(Painter& painter) const;
+    void paintSelectionText(Painter& painter, bool forward) const;
+    void paintSelectionPhrase(Painter& painter, bool forward) const;
+    void paintSelectionLines(Painter& painter, bool forward) const;
+    void paintSelection(Painter& painter, bool forward) const;
     void paintError(Painter& painter) const;
     void paintErrorSelectionless(Painter& painter) const;
     void paintErrorText(Painter& painter) const;

--- a/src/typeset_subphrase.cpp
+++ b/src/typeset_subphrase.cpp
@@ -31,8 +31,8 @@ void Subphrase::setParent(Construct* c) noexcept{
 }
 
 #ifndef HOPE_TYPESET_HEADLESS
-void Subphrase::paint(Painter& painter) const{
-    if(numTexts() > 1 || !text(0)->empty()) Phrase::paint(painter);
+void Subphrase::paint(Painter& painter, bool forward) const{
+    if(numTexts() > 1 || !text(0)->empty()) Phrase::paint(painter, forward);
     else painter.drawEmptySubphrase(x, y, width, height());
 }
 

--- a/src/typeset_subphrase.h
+++ b/src/typeset_subphrase.h
@@ -18,7 +18,7 @@ public:
     Construct* parent;
 
     #ifndef HOPE_TYPESET_HEADLESS
-    virtual void paint(Painter& painter) const override;
+    virtual void paint(Painter& painter, bool forward = true) const override;
     virtual void resize() noexcept override;
     #endif
 };

--- a/src/typeset_text.cpp
+++ b/src/typeset_text.cpp
@@ -351,63 +351,67 @@ size_t Text::indexLeft(double x_in) const noexcept{
     return size();
 }
 
-void Text::paint(Painter& painter) const{
+void Text::paint(Painter& painter, bool forward) const{
     size_t start = 0;
     double x = this->x;
     for(const SemanticTag& tag : tags){
-        painter.drawText(x, y, str.substr(start, tag.index-start));
-        x += painter.getWidth(str.substr(start, tag.index-start));
+        std::string substr = str.substr(start, tag.index-start);
+        painter.drawText(x, y, substr, forward);
+        x += painter.getWidth(substr);
         start = tag.index;
         painter.setType(tag.type);
     }
-    painter.drawText(x, y, str.substr(start));
+    painter.drawText(x, y, str.substr(start), forward);
 }
 
-void Text::paintUntil(Painter& painter, size_t stop) const{
+void Text::paintUntil(Painter& painter, size_t stop, bool forward) const{
     size_t start = 0;
     double x = this->x;
     for(const SemanticTag& tag : tags){
         if(tag.index >= stop) break;
-        painter.drawText(x, y, str.substr(start, tag.index-start));
-        x += painter.getWidth(str.substr(start, tag.index-start));
+        std::string substr = str.substr(start, tag.index-start);
+        painter.drawText(x, y, substr, forward);
+        x += painter.getWidth(substr);
         start = tag.index;
         painter.setType(tag.type);
     }
-    painter.drawText(x, y, str.substr(start, stop - start));
+    painter.drawText(x, y, str.substr(start, stop - start), forward);
 }
 
-void Text::paintAfter(Painter& painter, size_t start) const{
+void Text::paintAfter(Painter& painter, size_t start, bool forward) const{
     double x = this->x + xLocal(start);
     painter.setType(getTypeLeftOf(start));
 
     for(const SemanticTag& tag : tags){
         if(tag.index > start){
-            painter.drawText(x, y, str.substr(start, tag.index-start));
-            x += painter.getWidth(str.substr(start, tag.index-start));
+            std::string substr = str.substr(start, tag.index-start);
+            painter.drawText(x, y, substr, forward);
+            x += painter.getWidth(substr);
             start = tag.index;
             painter.setType(tag.type);
         }
     }
 
-    painter.drawText(x, y, str.substr(start));
+    painter.drawText(x, y, str.substr(start), forward);
 }
 
-void Text::paintMid(Painter& painter, size_t start, size_t stop) const{
+void Text::paintMid(Painter& painter, size_t start, size_t stop, bool forward) const{
+    painter.setScriptLevel(scriptDepth());
     double x = this->x + xLocal(start);
     painter.setType(getTypeLeftOf(start));
-    painter.setScriptLevel(scriptDepth());
 
     for(const SemanticTag& tag : tags){
         if(tag.index > start){
             if(tag.index >= stop) break;
-            painter.drawText(x, y, str.substr(start, tag.index-start));
-            x += painter.getWidth(str.substr(start, tag.index-start));
+            std::string substr = str.substr(start, tag.index-start);
+            painter.drawText(x, y, substr, forward);
+            x += painter.getWidth(substr);
             start = tag.index;
             painter.setType(tag.type);
         }
     }
 
-    painter.drawText(x, y, str.substr(start, stop-start));
+    painter.drawText(x, y, str.substr(start, stop-start), forward);
 }
 
 bool Text::containsX(double x_test) const noexcept{

--- a/src/typeset_text.h
+++ b/src/typeset_text.h
@@ -79,10 +79,10 @@ class Text {
         uint8_t scriptDepth() const noexcept;
         size_t indexNearest(double x_in) const noexcept;
         size_t indexLeft(double x_in) const noexcept;
-        void paint(Painter& painter) const;
-        void paintUntil(Painter& painter, size_t stop) const;
-        void paintAfter(Painter& painter, size_t start) const;
-        void paintMid(Painter& painter, size_t start, size_t stop) const;
+        void paint(Painter& painter, bool forward = true) const;
+        void paintUntil(Painter& painter, size_t stop, bool forward = true) const;
+        void paintAfter(Painter& painter, size_t start, bool forward = true) const;
+        void paintMid(Painter& painter, size_t start, size_t stop, bool forward = true) const;
         bool containsX(double x_test) const noexcept;
         bool containsY(double y_test) const noexcept;
         bool containsXInBounds(double x_test, size_t start, size_t stop) const noexcept;


### PR DESCRIPTION
This finally solves https://github.com/JohnDTill/Forscape/issues/12 without compromise. The only change in text positioning comes in the transition from unselected to selected, which is imperceptible since the colours are inverted.