### PR TITLE
Poll file changes and cache load/save dir

### DIFF
--- a/example/exampleWidgetQt/mainwindow.h
+++ b/example/exampleWidgetQt/mainwindow.h
@@ -71,6 +71,7 @@ private slots:
     void onTextChanged();
     void on_actionShow_action_toolbar_toggled(bool show);
     void on_actionShow_typesetting_toolbar_toggled(bool show);
+    void checkForChanges();
 
 protected:
     virtual void closeEvent(QCloseEvent* event) override;
@@ -79,5 +80,6 @@ private:
     bool savePrompt();
     bool saveAs(QString name);
     void open(QString path);
+    QString getLastDir();
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
The app will poll to see if the active file has been modified externally. The directory is cached for loading/saving, so that subsequent prompts will start in that location.