### PR TITLE
Editor shortcut customisation

### DIFF
--- a/example/exampleWidgetQt/CMakeLists.txt
+++ b/example/exampleWidgetQt/CMakeLists.txt
@@ -57,6 +57,7 @@ set(GEN_FILES
     ${GEN}/typeset_closesymbol.h
     ${GEN}/typeset_keywords.cpp
     ${GEN}/typeset_keywords.h
+    ${GEN}/typeset_shorthand.cpp
     ${GEN}/typeset_shorthand.h
     ${GEN}/typeset_themes.cpp
     ${GEN}/typeset_themes.h
@@ -121,8 +122,8 @@ set(CONSTRUCT_FILES
 
 set(PROJECT_SOURCES
     main.cpp
-    keywordsubtitutioneditor.cpp
-    keywordsubtitutioneditor.h
+    keywordsubstitutioneditor.cpp
+    keywordsubstitutioneditor.h
     mainwindow.cpp
     mainwindow.h
     mainwindow.ui
@@ -137,11 +138,14 @@ set(PROJECT_SOURCES
     searchdialog.cpp
     searchdialog.h
     searchdialog.ui
+    symbolsubstitutioneditor.cpp
+    symbolsubstitutioneditor.h
     symboltreeview.cpp
     symboltreeview.h
     ${EMBEDDED_RESOURCES}
     ${GEN_FILES}
     ${CONSTRUCT_FILES}
+    ${SRC}/hope_common.h
     ${SRC}/hope_error.cpp
     ${INCLUDE}/hope_error.h
     ${SRC}/hope_interpreter.cpp

--- a/example/exampleWidgetQt/CMakeLists.txt
+++ b/example/exampleWidgetQt/CMakeLists.txt
@@ -121,6 +121,8 @@ set(CONSTRUCT_FILES
 
 set(PROJECT_SOURCES
     main.cpp
+    keywordsubtitutioneditor.cpp
+    keywordsubtitutioneditor.h
     mainwindow.cpp
     mainwindow.h
     mainwindow.ui

--- a/example/exampleWidgetQt/keywordsubstitutioneditor.h
+++ b/example/exampleWidgetQt/keywordsubstitutioneditor.h
@@ -1,5 +1,5 @@
-#ifndef KEYWORDSUBTITUTIONEDITOR_H
-#define KEYWORDSUBTITUTIONEDITOR_H
+#ifndef KEYWORDSUBSTITUTIONEDITOR_H
+#define KEYWORDSUBSTITUTIONEDITOR_H
 
 #include <QWidget>
 
@@ -7,12 +7,12 @@ class QFormLayout;
 class QSettings;
 class QValidator;
 
-class KeywordSubtitutionEditor : public QWidget{
+class KeywordSubstitutionEditor : public QWidget{
     Q_OBJECT
 
 public:
-    KeywordSubtitutionEditor(QSettings& settings, QWidget* parent = nullptr);
-    ~KeywordSubtitutionEditor();
+    KeywordSubstitutionEditor(QSettings& settings, QWidget* parent = nullptr);
+    ~KeywordSubstitutionEditor();
     void resetDefaults();
     void addSlot();
 
@@ -28,7 +28,7 @@ private:
         ModifiedLineEdit* edit;
         QString backup;
 
-        KeywordSubstitutionLabel(KeywordSubtitutionEditor* parent = nullptr, const std::string& label = "");
+        KeywordSubstitutionLabel(KeywordSubstitutionEditor* parent = nullptr, const std::string& label = "");
     };
 
     KeywordSubstitutionLabel* getButtonLabel() const;
@@ -44,4 +44,4 @@ private:
     KeywordSubstitutionLabel* focused_label = nullptr;
 };
 
-#endif // KEYWORDSUBTITUTIONEDITOR_H
+#endif // KEYWORDSUBSTITUTIONEDITOR_H

--- a/example/exampleWidgetQt/keywordsubtitutioneditor.cpp
+++ b/example/exampleWidgetQt/keywordsubtitutioneditor.cpp
@@ -1,0 +1,167 @@
+#include "keywordsubtitutioneditor.h"
+
+#include <typeset_keywords.h>
+#include <typeset_view.h>
+#include <cassert>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSettings>
+
+class KeywordSubtitutionEditor::ModifiedLineEdit : public QLineEdit {
+public:
+    ModifiedLineEdit(QWidget* parent = nullptr)
+        : QLineEdit(parent){}
+
+protected:
+    void focusInEvent(QFocusEvent* event) override final{
+        KeywordSubstitutionLabel* label = static_cast<KeywordSubstitutionLabel*>(parentWidget());
+        KeywordSubtitutionEditor* editor = static_cast<KeywordSubtitutionEditor*>(label->parentWidget());
+        editor->focused_label = label;
+
+        QLineEdit::focusInEvent(event);
+    }
+};
+
+KeywordSubtitutionEditor::KeywordSubtitutionEditor(QSettings& settings, QWidget* parent)
+    : QWidget(parent),
+      form(new QFormLayout(this)),
+      settings(settings),
+      validator(validator = new QRegExpValidator(QRegExp("^[a-zA-Z0-9_]*"), this)) {
+    setLayout(form);
+
+    if(settings.contains("KEYWORD_SHORTCUTS")) load();
+    else populateDefaults();
+}
+
+KeywordSubtitutionEditor::~KeywordSubtitutionEditor(){
+    const auto to_save = getSortedMap();
+    QMap<QString, QVariant> map;
+    for(const auto& entry : to_save)
+        map.insert(QString::fromStdString(entry.first), QString::fromStdString(entry.second));
+    settings.setValue("KEYWORD_SHORTCUTS", map);
+}
+
+void KeywordSubtitutionEditor::resetDefaults(){
+    Hope::Typeset::Keywords::reset();
+    for(auto item : form->children()) delete item;
+    delete form;
+    form = new QFormLayout(this);
+    setLayout(form);
+    populateDefaults();
+}
+
+void KeywordSubtitutionEditor::addSlot(){
+    if(!getBottomEdit()->text().isEmpty()) addRowForEntry("", "");
+    getBottomEdit()->setFocus();
+}
+
+void KeywordSubtitutionEditor::remove(){
+    KeywordSubstitutionLabel* label = getButtonLabel();
+    Hope::Typeset::Keywords::map.erase(label->backup.toStdString());
+    form->removeRow(label);
+}
+
+void KeywordSubtitutionEditor::updateKeyword(){
+    KeywordSubstitutionLabel* label = focused_label;
+    ModifiedLineEdit* edit = label->edit;
+    const QString& new_keyword = edit->text();
+    std::string keyword = new_keyword.toStdString();
+
+    if(keyword.empty()){
+        QMessageBox::warning(this, "Keyword rejected", "Keyword cannot be empty");
+        edit->setText(label->backup);
+    }else if(new_keyword == label->backup){
+        return;
+    }else if(Hope::Typeset::Keywords::map.find(keyword) != Hope::Typeset::Keywords::map.end()){
+        QMessageBox::warning(this, "Keyword rejected", "Key \"" + new_keyword + "\" already exists");
+        edit->setText(label->backup);
+    }else{
+        auto result = form->itemAt(form->indexOf(label) + 1);
+        assert(dynamic_cast<Hope::Typeset::LineEdit*>(result->widget()));
+        Hope::Typeset::Keywords::map[keyword] = static_cast<Hope::Typeset::LineEdit*>(result->widget())->toSerial();
+        Hope::Typeset::Keywords::map.erase(label->backup.toStdString());
+        label->backup = new_keyword;
+    }
+}
+
+void KeywordSubtitutionEditor::updateResult(){
+    QWidget* sender = focusWidget();
+    assert(dynamic_cast<Hope::Typeset::LineEdit*>(sender));
+    auto result_edit = static_cast<Hope::Typeset::LineEdit*>(sender);
+    auto upcast_label = form->labelForField(sender);
+    assert(dynamic_cast<KeywordSubstitutionLabel*>(upcast_label));
+    KeywordSubstitutionLabel* label = static_cast<KeywordSubstitutionLabel*>(upcast_label);
+    Hope::Typeset::Keywords::map[label->backup.toStdString()] = result_edit->toSerial();
+}
+
+void KeywordSubtitutionEditor::populateDefaults(){
+    for(const auto& entry : getSortedMap())
+        addRowForEntry(entry.first, entry.second);
+}
+
+void KeywordSubtitutionEditor::load(){
+    assert(settings.contains("KEYWORD_SHORTCUTS"));
+    auto map = settings.value("KEYWORD_SHORTCUTS").toMap();
+
+    Hope::Typeset::Keywords::map.clear();
+    for(auto it = map.constKeyValueBegin(); it != map.constKeyValueEnd(); it++){
+        std::string keyword = it->first.toStdString();
+        std::string result = it->second.toString().toStdString();
+
+        auto op = Hope::Typeset::Keywords::map.insert({keyword, result});
+        assert(op.second); //Should not have saved with duplicates
+        addRowForEntry(keyword, result);
+    }
+}
+
+void KeywordSubtitutionEditor::addRowForEntry(const std::string& keyword, const std::string& result){
+    auto result_edit = new Hope::Typeset::LineEdit();
+    result_edit->setFromSerial(result, true);
+    result_edit->setToolTip("Result");
+    connect(result_edit, SIGNAL(textChanged()), this, SLOT(updateResult()));
+    form->addRow(new KeywordSubstitutionLabel(this, keyword), result_edit);
+}
+
+std::vector<std::pair<std::string, std::string>> KeywordSubtitutionEditor::getSortedMap(){
+    typedef std::pair<std::string, std::string> Entry;
+    std::vector<Entry> entries;
+    for(const auto& entry : Hope::Typeset::Keywords::map)
+        entries.push_back(entry);
+
+    std::sort(entries.begin(), entries.end(), [](const Entry& a, const Entry& b){return a.first < b.first;});
+
+    return entries;
+}
+
+KeywordSubtitutionEditor::KeywordSubstitutionLabel* KeywordSubtitutionEditor::getButtonLabel() const{
+    QWidget* sender = focusWidget();
+    assert(dynamic_cast<KeywordSubstitutionLabel*>(sender->parentWidget()));
+    return static_cast<KeywordSubstitutionLabel*>(sender->parentWidget());
+}
+
+KeywordSubtitutionEditor::ModifiedLineEdit* KeywordSubtitutionEditor::getBottomEdit() const{
+    auto label = form->itemAt(form->count()-2)->widget();
+    assert(dynamic_cast<KeywordSubstitutionLabel*>(label));
+    return static_cast<KeywordSubstitutionLabel*>(label)->edit;
+}
+
+KeywordSubtitutionEditor::KeywordSubstitutionLabel::KeywordSubstitutionLabel(
+        KeywordSubtitutionEditor* parent, const std::string& label)
+    : QWidget(parent) {
+    auto layout = new QHBoxLayout(this);
+    setLayout(layout);
+    auto* remove = new QPushButton(this);
+    remove->setText("✕");
+    remove->setFixedSize(20, 20);
+    connect(remove, SIGNAL(clicked()), parent, SLOT(remove()));
+    layout->addWidget(remove);
+    edit = new ModifiedLineEdit(this);
+    edit->setValidator(parent->validator);
+    edit->setToolTip("Keyword");
+    backup = QString::fromStdString(label);
+    edit->setText(backup);
+    connect(edit, SIGNAL(editingFinished()), parent, SLOT(updateKeyword()));
+    layout->addWidget(edit);
+}

--- a/example/exampleWidgetQt/keywordsubtitutioneditor.h
+++ b/example/exampleWidgetQt/keywordsubtitutioneditor.h
@@ -1,0 +1,47 @@
+#ifndef KEYWORDSUBTITUTIONEDITOR_H
+#define KEYWORDSUBTITUTIONEDITOR_H
+
+#include <QWidget>
+
+class QFormLayout;
+class QSettings;
+class QValidator;
+
+class KeywordSubtitutionEditor : public QWidget{
+    Q_OBJECT
+
+public:
+    KeywordSubtitutionEditor(QSettings& settings, QWidget* parent = nullptr);
+    ~KeywordSubtitutionEditor();
+    void resetDefaults();
+    void addSlot();
+
+private slots:
+    void remove();
+    void updateKeyword();
+    void updateResult();
+
+private:
+    class ModifiedLineEdit;
+    class KeywordSubstitutionLabel : public QWidget {
+    public:
+        ModifiedLineEdit* edit;
+        QString backup;
+
+        KeywordSubstitutionLabel(KeywordSubtitutionEditor* parent = nullptr, const std::string& label = "");
+    };
+
+    KeywordSubstitutionLabel* getButtonLabel() const;
+    ModifiedLineEdit* getBottomEdit() const;
+    void populateDefaults();
+    void load();
+    void addRowForEntry(const std::string& keyword, const std::string& result);
+    static std::vector<std::pair<std::string, std::string>> getSortedMap();
+
+    QFormLayout* form;
+    QSettings& settings;
+    QValidator* validator;
+    KeywordSubstitutionLabel* focused_label = nullptr;
+};
+
+#endif // KEYWORDSUBTITUTIONEDITOR_H

--- a/example/exampleWidgetQt/mainwindow.cpp
+++ b/example/exampleWidgetQt/mainwindow.cpp
@@ -707,6 +707,7 @@ void MainWindow::closeEvent(QCloseEvent* event){
 
     logger->info("assert(editor->toSerial() == {});", cStr(editor->toSerial()));
 
+    preferences->close();
     QMainWindow::closeEvent(event);
 }
 

--- a/example/exampleWidgetQt/mainwindow.cpp
+++ b/example/exampleWidgetQt/mainwindow.cpp
@@ -76,7 +76,7 @@ MainWindow::MainWindow(QWidget* parent)
     QSplitter* splitter = new QSplitter(Qt::Vertical, this);
     setCentralWidget(splitter);
 
-    editor = new Typeset::View();
+    editor = new Typeset::Editor();
     setWindowTitle(NEW_SCRIPT_TITLE WINDOW_TITLE_SUFFIX);
     if(settings.contains(ACTIVE_FILE))
         open(settings.value(ACTIVE_FILE).toString());
@@ -92,9 +92,7 @@ MainWindow::MainWindow(QWidget* parent)
     splitter->setStretchFactor(0, 2);
     splitter->setStretchFactor(1, 1);
 
-    console = new Typeset::View();
-    console->setLineNumbersVisible(false);
-    console->setReadOnly(true);
+    console = new Typeset::Console();
     vbox->addWidget(console);
 
     editor->console = console;

--- a/example/exampleWidgetQt/mainwindow.h
+++ b/example/exampleWidgetQt/mainwindow.h
@@ -16,7 +16,8 @@ class QGroupBox;
 
 namespace Hope{
 namespace Typeset {
-class View;
+class Console;
+class Editor;
 }
 }
 
@@ -30,8 +31,8 @@ public:
 private:
     QSettings settings;
     Ui::MainWindow* ui;
-    Hope::Typeset::View* editor;
-    Hope::Typeset::View* console;
+    Hope::Typeset::Editor* editor;
+    Hope::Typeset::Console* console;
     QGroupBox* group_box;
     MathToolbar* math_toolbar;
     QToolBar* action_toolbar;

--- a/example/exampleWidgetQt/mathtoolbar.h
+++ b/example/exampleWidgetQt/mathtoolbar.h
@@ -9,7 +9,7 @@ class MathToolbar : public QToolBar{
     Q_OBJECT
 
 private:
-    QTableWidget* symbol_table;
+    QTableWidget* symbol_table; //EVENTUALLY: symbols can change based on keywords
 
 public:
     MathToolbar(QWidget* parent = nullptr);

--- a/example/exampleWidgetQt/preferences.cpp
+++ b/example/exampleWidgetQt/preferences.cpp
@@ -1,8 +1,10 @@
 #include "preferences.h"
 #include "ui_preferences.h"
 
+#include "keywordsubtitutioneditor.h"
 #include <typeset_themes.h>
 #include <QColorDialog>
+#include <QScrollBar>
 #include <QSettings>
 #include <QWindow>
 
@@ -21,7 +23,7 @@ Preferences::Preferences(QSettings& settings, QWidget* parent) :
         else for(size_t i = 0; i < Hope::Typeset::NUM_COLOUR_PRESETS; i++)
             if(colour_preset == Hope::Typeset::getPresetName(i).data()){
                 Hope::Typeset::setPreset(i);
-                ui->colour_dropdown->setCurrentIndex(i);
+                ui->colour_dropdown->setCurrentIndex(static_cast<int>(i));
             }
     }
 
@@ -51,6 +53,9 @@ Preferences::Preferences(QSettings& settings, QWidget* parent) :
         row_item->setText(Hope::Typeset::getColourName(i).data());
         ui->colour_table->setVerticalHeaderItem(i, row_item);
     }
+
+    keyword_editor = new KeywordSubtitutionEditor(settings, ui->scrollArea);
+    ui->scrollArea->setWidget(keyword_editor);
 }
 
 Preferences::~Preferences(){
@@ -70,7 +75,7 @@ void Preferences::onPresetSelect(int index){
     Hope::Typeset::setPreset(index);
 
     for(size_t i = 0; i < Hope::Typeset::NUM_COLOUR_ROLES; i++){
-        QTableWidgetItem* item = ui->colour_table->item(i, 0);
+        QTableWidgetItem* item = ui->colour_table->item(static_cast<int>(i), 0);
         item->setBackground(Hope::Typeset::getColour(i));
     }
 
@@ -106,3 +111,17 @@ void Preferences::updateWindows() const{
     for(auto window : QGuiApplication::topLevelWindows())
         window->requestUpdate();
 }
+
+void Preferences::on_keywordDefaultsButton_clicked(){
+    keyword_editor->resetDefaults();
+}
+
+
+void Preferences::on_keywordAddButton_clicked(){
+    keyword_editor->addSlot();
+    QCoreApplication::processEvents();
+    QCoreApplication::processEvents();
+    auto scrollbar = ui->scrollArea->verticalScrollBar();
+    scrollbar->setValue(scrollbar->maximum());
+}
+

--- a/example/exampleWidgetQt/preferences.cpp
+++ b/example/exampleWidgetQt/preferences.cpp
@@ -1,12 +1,13 @@
 #include "preferences.h"
 #include "ui_preferences.h"
 
-#include "keywordsubtitutioneditor.h"
+#include "keywordsubstitutioneditor.h"
 #include <typeset_themes.h>
 #include <QColorDialog>
 #include <QScrollBar>
 #include <QSettings>
 #include <QWindow>
+#include "symbolsubstitutioneditor.h"
 
 Preferences::Preferences(QSettings& settings, QWidget* parent) :
     QWidget(parent), ui(new Ui::Preferences), settings(settings){
@@ -54,8 +55,11 @@ Preferences::Preferences(QSettings& settings, QWidget* parent) :
         ui->colour_table->setVerticalHeaderItem(i, row_item);
     }
 
-    keyword_editor = new KeywordSubtitutionEditor(settings, ui->scrollArea);
+    keyword_editor = new KeywordSubstitutionEditor(settings, ui->scrollArea);
     ui->scrollArea->setWidget(keyword_editor);
+
+    symbol_editor = new SymbolSubstitutionEditor(settings, this);
+    ui->symbolLayout->insertWidget(1, symbol_editor);
 }
 
 Preferences::~Preferences(){
@@ -123,5 +127,15 @@ void Preferences::on_keywordAddButton_clicked(){
     QCoreApplication::processEvents();
     auto scrollbar = ui->scrollArea->verticalScrollBar();
     scrollbar->setValue(scrollbar->maximum());
+}
+
+
+void Preferences::on_symbolsDefaultsButton_clicked(){
+    symbol_editor->resetDefaults();
+}
+
+
+void Preferences::on_symbolsAddButton_clicked(){
+    symbol_editor->addRow();
 }
 

--- a/example/exampleWidgetQt/preferences.h
+++ b/example/exampleWidgetQt/preferences.h
@@ -1,9 +1,10 @@
 #ifndef PREFERENCES_H
 #define PREFERENCES_H
 
-class KeywordSubtitutionEditor;
+class KeywordSubstitutionEditor;
 class QSettings;
 class QTableWidgetItem;
+class SymbolSubstitutionEditor;
 #include <QWidget>
 
 namespace Ui {
@@ -21,8 +22,9 @@ private slots:
     void onPresetSelect(int index);
     void onColourSelect(QTableWidgetItem* item);
     void on_keywordDefaultsButton_clicked();
-
     void on_keywordAddButton_clicked();
+    void on_symbolsDefaultsButton_clicked();
+    void on_symbolsAddButton_clicked();
 
 signals:
     void colourChanged();
@@ -33,7 +35,8 @@ private:
     void updateWindows() const;
     Ui::Preferences* ui;
     QSettings& settings;
-    KeywordSubtitutionEditor* keyword_editor;
+    KeywordSubstitutionEditor* keyword_editor;
+    SymbolSubstitutionEditor* symbol_editor;
 };
 
 #endif // PREFERENCES_H

--- a/example/exampleWidgetQt/preferences.h
+++ b/example/exampleWidgetQt/preferences.h
@@ -1,6 +1,7 @@
 #ifndef PREFERENCES_H
 #define PREFERENCES_H
 
+class KeywordSubtitutionEditor;
 class QSettings;
 class QTableWidgetItem;
 #include <QWidget>
@@ -13,12 +14,15 @@ class Preferences : public QWidget{
     Q_OBJECT
 
 public:
-    explicit Preferences(QSettings& settings, QWidget* parent = nullptr);
+    Preferences(QSettings& settings, QWidget* parent = nullptr);
     ~Preferences();
 
 private slots:
     void onPresetSelect(int index);
     void onColourSelect(QTableWidgetItem* item);
+    void on_keywordDefaultsButton_clicked();
+
+    void on_keywordAddButton_clicked();
 
 signals:
     void colourChanged();
@@ -29,6 +33,7 @@ private:
     void updateWindows() const;
     Ui::Preferences* ui;
     QSettings& settings;
+    KeywordSubtitutionEditor* keyword_editor;
 };
 
 #endif // PREFERENCES_H

--- a/example/exampleWidgetQt/preferences.ui
+++ b/example/exampleWidgetQt/preferences.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="colours">
       <attribute name="title">
@@ -48,7 +48,7 @@
      </widget>
      <widget class="QWidget" name="Commands">
       <attribute name="title">
-       <string>Keywords</string>
+       <string>Keyword Shortcuts</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
@@ -82,6 +82,31 @@
           <string>Add Keyword</string>
          </property>
         </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="symbolPage">
+      <attribute name="title">
+       <string>Symbol Shortcuts</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QVBoxLayout" name="symbolLayout">
+         <item>
+          <widget class="QPushButton" name="symbolsDefaultsButton">
+           <property name="text">
+            <string>Reset Defaults</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="symbolsAddButton">
+           <property name="text">
+            <string>Add Entry</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/example/exampleWidgetQt/preferences.ui
+++ b/example/exampleWidgetQt/preferences.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="colours">
       <attribute name="title">
@@ -48,8 +48,42 @@
      </widget>
      <widget class="QWidget" name="Commands">
       <attribute name="title">
-       <string>Commands</string>
+       <string>Keywords</string>
       </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QPushButton" name="keywordDefaultsButton">
+         <property name="text">
+          <string>Reset Defaults</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QScrollArea" name="scrollArea">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>358</width>
+            <height>172</height>
+           </rect>
+          </property>
+          <layout class="QGridLayout" name="gridLayout"/>
+         </widget>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="keywordAddButton">
+         <property name="text">
+          <string>Add Keyword</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>

--- a/example/exampleWidgetQt/preferences.ui
+++ b/example/exampleWidgetQt/preferences.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="colours">
       <attribute name="title">

--- a/example/exampleWidgetQt/symbolsubstitutioneditor.cpp
+++ b/example/exampleWidgetQt/symbolsubstitutioneditor.cpp
@@ -1,0 +1,219 @@
+#include "symbolsubstitutioneditor.h"
+
+#include <hope_unicode.h>
+#include <typeset_shorthand.h>
+#include <QCoreApplication>
+#include <QHeaderView>
+#include <QScrollBar>
+#include <QSettings>
+using Hope::Typeset::Shorthand;
+
+static int FIRST_COL = 0;
+static int SECOND_COL = 1;
+static int RESULT_COL = 2;
+
+#define CLOSE_SYMBOL " ✕ "
+#define FIELD_NAME "SHORTHAND"
+
+SymbolSubstitutionEditor::SymbolSubstitutionEditor(QSettings& settings, QWidget* parent)
+    : QTableWidget(parent), settings(settings) {
+    setColumnCount(3);
+    setHorizontalHeaderLabels({"First", "Second", "Result"});
+
+    if(settings.contains(FIELD_NAME)) load();
+    populateFromMap();
+
+    connect(this, SIGNAL(cellChanged(int,int)), this, SLOT(onItemEdited(int,int)));
+    connect(verticalHeader(), SIGNAL(sectionClicked(int)), this, SLOT(removeRow(int)));
+    connect(this, SIGNAL(cellClicked(int,int)), this, SLOT(onItemEdited(int,int)));
+}
+
+SymbolSubstitutionEditor::~SymbolSubstitutionEditor(){
+    QList<QVariant> list;
+
+    for(const auto& entry : Shorthand::map){
+        list.append(entry.first.first);
+        list.append(entry.first.second);
+        list.append(QString::fromStdString(entry.second));
+    }
+
+    settings.setValue(FIELD_NAME, list);
+}
+
+void SymbolSubstitutionEditor::resetDefaults(){
+    Shorthand::reset();
+    clear();
+
+    setColumnCount(3);
+    setHorizontalHeaderLabels({"First", "Second", "Result"});
+    blockSignals(true);
+    populateFromMap();
+    blockSignals(false);
+}
+
+void SymbolSubstitutionEditor::addRow(){
+    blockSignals(true);
+
+    int row = rowCount();
+    setRowCount(rowCount()+1);
+
+    QTableWidgetItem* first_item = new QTableWidgetItem();
+    first_item->setTextAlignment(Qt::AlignCenter);
+    first_item->setData(Qt::UserRole, uint(0));
+    setItem(row, FIRST_COL, first_item);
+
+    QTableWidgetItem* second_item = new QTableWidgetItem();
+    second_item->setTextAlignment(Qt::AlignCenter);
+    second_item->setData(Qt::UserRole, uint(0));
+    setItem(row, SECOND_COL, second_item);
+
+    QTableWidgetItem* final_item = new QTableWidgetItem();
+    final_item->setTextAlignment(Qt::AlignCenter);
+    final_item->setData(Qt::UserRole, QString());
+    setItem(row, RESULT_COL, final_item);
+
+    QTableWidgetItem* row_item = new QTableWidgetItem();
+    row_item->setText(CLOSE_SYMBOL);
+    setVerticalHeaderItem(row, row_item);
+
+    blockSignals(false);
+
+    QScrollBar* v_scroll = verticalScrollBar();
+    QCoreApplication::processEvents();
+    v_scroll->setValue(v_scroll->maximum());
+}
+
+void SymbolSubstitutionEditor::removeRow(int row){
+    uint32_t first = getCode(row, FIRST_COL);
+    uint32_t second = getCode(row, SECOND_COL);
+    Shorthand::map.erase(std::make_pair(first, second));
+
+    QTableWidget::removeRow(row);
+}
+
+void SymbolSubstitutionEditor::onItemEdited(int row, int column){
+    if(column == FIRST_COL || column == SECOND_COL || column == RESULT_COL) updateRow(row);
+}
+
+void SymbolSubstitutionEditor::load(){
+    assert(settings.contains(FIELD_NAME));
+
+    QList<QVariant> list = settings.value(FIELD_NAME).toList();
+    assert(list.size() % 3 == 0);
+    Shorthand::map.clear();
+    for(int i = 0; i < list.size(); i += 3){
+        bool success;
+        uint32_t first = list[i].toUInt(&success);
+        assert(success);
+        uint32_t second = list[i+1].toUInt(&success);
+        assert(success);
+        QString result = list[i+2].toString();
+        assert(Shorthand::map.find(std::make_pair(first, second)) == Shorthand::map.end());
+        Shorthand::map[std::make_pair(first, second)] = result.toStdString();
+    }
+}
+
+void SymbolSubstitutionEditor::populateFromMap(){
+    setRowCount(static_cast<int>(Shorthand::map.size()));
+    int row = 0;
+    for(const auto& entry : Shorthand::map){
+        QTableWidgetItem* first_item = new QTableWidgetItem();
+        first_item->setTextAlignment(Qt::AlignCenter);
+        uint32_t first = entry.first.first;
+        first_item->setData(Qt::UserRole, first);
+        first_item->setText(QString::fromStdString(Hope::fromCode(first)));
+        setItem(row, FIRST_COL, first_item);
+
+        QTableWidgetItem* second_item = new QTableWidgetItem();
+        second_item->setTextAlignment(Qt::AlignCenter);
+        uint32_t second = entry.first.second;
+        second_item->setData(Qt::UserRole, second);
+        second_item->setText(QString::fromStdString(Hope::fromCode(second)));
+        setItem(row, SECOND_COL, second_item);
+
+        QTableWidgetItem* final_item = new QTableWidgetItem();
+        final_item->setTextAlignment(Qt::AlignCenter);
+        QString result = QString::fromStdString(entry.second);
+        final_item->setData(Qt::UserRole, result);
+        final_item->setText(result);
+        setItem(row, RESULT_COL, final_item);
+
+        QTableWidgetItem* row_item = new QTableWidgetItem();
+        row_item->setText(CLOSE_SYMBOL);
+        setVerticalHeaderItem(row, row_item);
+
+        row++;
+    }
+}
+
+#define GOOD_BRUSH QBrush()
+#define BAD_BRUSH QBrush(Qt::red)
+
+void SymbolSubstitutionEditor::updateRow(int row) {
+    uint32_t first = getCode(row, FIRST_COL);
+    uint32_t second = getCode(row, SECOND_COL);
+    const QString& result = item(row, RESULT_COL)->text();
+
+    if(!first){
+        item(row, FIRST_COL)->setBackground(BAD_BRUSH);
+        item(row, FIRST_COL)->setToolTip("Must be a single, non-space character");
+    }else{
+        item(row, FIRST_COL)->setBackground(GOOD_BRUSH);
+        item(row, FIRST_COL)->setToolTip(QString());
+    }
+
+    if(!second){
+        item(row, SECOND_COL)->setBackground(BAD_BRUSH);
+        item(row, SECOND_COL)->setToolTip("Must be a single, non-space character");
+    }else{
+        item(row, SECOND_COL)->setBackground(GOOD_BRUSH);
+        item(row, SECOND_COL)->setToolTip(QString());
+    }
+
+    if(result.isEmpty()){
+        item(row, RESULT_COL)->setBackground(BAD_BRUSH);
+        item(row, RESULT_COL)->setToolTip("Result cannot be empty");
+    }else{
+        item(row, RESULT_COL)->setBackground(GOOD_BRUSH);
+        item(row, RESULT_COL)->setToolTip(QString());
+    }
+
+    if(!first || !second) return;
+
+    uint32_t old_first = item(row, FIRST_COL)->data(Qt::UserRole).toUInt();
+    uint32_t old_second = item(row, SECOND_COL)->data(Qt::UserRole).toUInt();
+    QString old_result = item(row, RESULT_COL)->data(Qt::UserRole).toString();
+    bool key_unchanged = (first == old_first && second == old_second);
+
+    if(key_unchanged){
+        if(result == old_result || result.isEmpty()) return;
+        Shorthand::map[std::make_pair(first, second)] = result.toStdString();
+        blockSignals(true);
+        item(row, RESULT_COL)->setData(Qt::UserRole, result);
+        blockSignals(false);
+    }else if(!result.isEmpty()){
+        auto in = Shorthand::map.insert({std::make_pair(first, second), result.toStdString()});
+        if(in.second){
+            Shorthand::map.erase(std::make_pair(old_first, old_second));
+            blockSignals(true);
+            item(row, FIRST_COL)->setData(Qt::UserRole, first);
+            item(row, SECOND_COL)->setData(Qt::UserRole, second);
+            item(row, RESULT_COL)->setData(Qt::UserRole, result);
+            blockSignals(false);
+        }else{
+            item(row, FIRST_COL)->setBackground(BAD_BRUSH);
+            item(row, FIRST_COL)->setToolTip("Previously defined");
+            item(row, SECOND_COL)->setBackground(BAD_BRUSH);
+            item(row, SECOND_COL)->setToolTip("Previously defined");
+        }
+    }
+}
+
+uint32_t SymbolSubstitutionEditor::getCode(int row, int col) const {
+    assert(col == FIRST_COL || col == SECOND_COL);
+    assert(row < rowCount());
+
+    std::string str = item(row, col)->text().toStdString();
+    if(!Hope::isSingleCodepoint(str) || str[0] == ' ') return 0;
+    return Hope::codepointInt(str);
+}

--- a/example/exampleWidgetQt/symbolsubstitutioneditor.h
+++ b/example/exampleWidgetQt/symbolsubstitutioneditor.h
@@ -1,0 +1,32 @@
+#ifndef SYMBOLSUBSTITUTIONEDITOR_H
+#define SYMBOLSUBSTITUTIONEDITOR_H
+
+#include <QTableWidget>
+
+class QSettings;
+
+class SymbolSubstitutionEditor : public QTableWidget{
+    Q_OBJECT
+
+public:
+    SymbolSubstitutionEditor(QSettings& settings, QWidget* parent = nullptr);
+    ~SymbolSubstitutionEditor();
+    void resetDefaults();
+    void addRow();
+
+private slots:
+    void removeRow(int row);
+    void onItemEdited(int row, int column);
+
+private:
+    void load();
+    void populateFromMap();
+    void updateRow(int row);
+    uint32_t getCode(int row, int col) const;
+    QSettings& settings;
+
+signals:
+
+};
+
+#endif // SYMBOLSUBSTITUTIONEDITOR_H

--- a/example/exampleWidgetQt/symboltreeview.cpp
+++ b/example/exampleWidgetQt/symboltreeview.cpp
@@ -13,11 +13,11 @@ SymbolTreeView::SymbolTreeView(const Hope::Code::SymbolTable& symbol_table, cons
     std::stack<QTreeWidgetItem*> items;
     for(const Hope::Code::ScopeSegment& scope : symbol_table.scopes){
         if(scope.isStartOfScope()){
-            if(scope.parent == Hope::Code::NONE){
+            if(scope.parent == NONE){
                 items.push(nullptr);
             }else{
                 Hope::Code::ScopeId grandparent = symbol_table.scopes[scope.parent].parent;
-                QTreeWidgetItem* scope_item = (grandparent == Hope::Code::NONE) ?
+                QTreeWidgetItem* scope_item = (grandparent == NONE) ?
                             new QTreeWidgetItem(this) :
                             new QTreeWidgetItem(items.top());
                 items.push(scope_item);
@@ -36,14 +36,14 @@ SymbolTreeView::SymbolTreeView(const Hope::Code::SymbolTable& symbol_table, cons
         }
 
         for(size_t i = scope.sym_begin; i < scope.sym_end; i++){
-            QTreeWidgetItem* item = (scope.parent == Hope::Code::NONE) ?
+            QTreeWidgetItem* item = (scope.parent == NONE) ?
                         new QTreeWidgetItem(this) :
                         new QTreeWidgetItem(items.top());
             const auto& symbol = symbol_table.symbols[i];
             item->setText(NAME_COLUMN, QString::fromStdString(symbol_table.getSel(i).str()));
             item->setText(1, QString::fromStdString(ts.typeString(symbol)));
             item->setText(2, QChar('0' + symbol.is_const));
-            if(symbol.comment != Hope::Code::ParseTree::EMPTY){
+            if(symbol.comment != NONE){
                 std::string desc = symbol_table.parse_tree.str(symbol.comment);
                 item->setText(3, QString::fromStdString(desc));
             }

--- a/include/typeset_view.h
+++ b/include/typeset_view.h
@@ -21,7 +21,7 @@ class View : public Widget {
 public:
     View();
     virtual ~View() override;
-    void setFromSerial(const std::string& src);
+    void setFromSerial(const std::string& src, bool is_output = false);
     std::string toSerial() const;
     Model* getModel() const noexcept;
     void setModel(Model* m, bool owned = true);
@@ -50,7 +50,7 @@ public:
     bool isRunning() const noexcept;
     void reenable() noexcept;
 
-private:
+protected:
     void dispatchClick(double x, double y, int xScreen, int yScreen, bool right_click, bool shift_held);
     void dispatchRelease(double x, double y);
     void dispatchDoubleClick(double x, double y);
@@ -98,10 +98,11 @@ private:
     Model* model;
     Controller controller;
     double x_setpoint = 0;
+    bool allow_new_line = true;
     bool show_line_nums = true;
     bool allow_write = true;
     bool insert_mode = false;
-    bool show_cursor = true;
+    bool show_cursor = false;
     bool model_owned = true;
     friend MarkerLink;
     public: double zoom = ZOOM_DEFAULT;
@@ -122,7 +123,7 @@ protected:
     QTimer* cursor_blink_timer;
     void onBlink() noexcept;
 
-private:
+protected:
     void setCursorAppearance(double x, double y);
     void drawBackground(const QRect& rect);
     void drawLinebox(double yT, double yB);
@@ -166,6 +167,25 @@ private:
 
 public:
     QImage toPng() const;
+};
+
+class Editor : public View {
+    //DO THIS: define hierarchy
+};
+
+class Console : public View {
+    //DO THIS: define hierarchy
+public:
+    Console() : View() {
+        setLineNumbersVisible(false);
+        setReadOnly(true);
+    }
+};
+
+class LineEdit : public View {
+    //DO THIS: define hierarchy
+public:
+    LineEdit();
 };
 
 }

--- a/include/typeset_view.h
+++ b/include/typeset_view.h
@@ -170,11 +170,11 @@ public:
 };
 
 class Editor : public View {
-    //DO THIS: define hierarchy
+    //EVENTUALLY: define hierarchy
 };
 
 class Console : public View {
-    //DO THIS: define hierarchy
+    //EVENTUALLY: define hierarchy
 public:
     Console() : View() {
         setLineNumbersVisible(false);
@@ -183,7 +183,7 @@ public:
 };
 
 class LineEdit : public View {
-    //DO THIS: define hierarchy
+    //EVENTUALLY: define hierarchy
 public:
     LineEdit();
 };

--- a/meta/typeset_shorthand.py
+++ b/meta/typeset_shorthand.py
@@ -9,7 +9,7 @@ def main():
     header_writer = cpp.HeaderWriter(
         name="Shorthand",
         inner_namespace="Typeset",
-        includes=("cassert", "limits", "unordered_map"),
+        includes=("cassert", "limits", "string", "unordered_map"),
     )
 
     header_writer.write(

--- a/meta/typeset_shorthand.py
+++ b/meta/typeset_shorthand.py
@@ -13,29 +13,35 @@ def main():
     )
 
     header_writer.write(
+        "struct PairHash {\n"
+        "    size_t operator()(const std::pair<uint32_t, uint32_t>& key) const noexcept {\n"
+        "        if(sizeof(size_t) > 4) return std::hash<size_t>()(\n"
+        "            static_cast<size_t>(key.first) |\n"
+        "            (static_cast<size_t>(key.second) << 32)\n"
+        "        );\n"
+        "        else return std::hash<uint32_t>()(key.first) ^ (std::hash<uint32_t>()(key.second) << 16);\n"
+        "    }\n"
+        "};\n\n")
+
+    header_writer.write(
         "class Shorthand{\n"
         "private:\n"
-        "    static const std::unordered_map<uint32_t, std::string> map;\n"
+        "    static const std::unordered_map<std::pair<uint32_t, uint32_t>, std::string, PairHash> map;\n"
         "    static const std::string NONE;\n"
         "\n"
         "public:\n"
         "    static const std::string& lookup(uint32_t first, uint32_t second) noexcept{\n"
-        "        assert(second <= std::numeric_limits<uint8_t>::max());\n"
-        "        assert(first <= (std::numeric_limits<uint32_t>::max() >> 8));\n"
-        "        uint32_t key = (first << 8) | second;\n"
-        "        auto result = map.find(key);\n"
+        "        auto result = map.find(std::make_pair(first, second));\n"
         "        return result==map.end() ? NONE : result->second;\n"
         "    }\n"
         "};\n\n"
         "const std::string Shorthand::NONE = \"\";\n\n"
     )
-    header_writer.write("const std::unordered_map<uint32_t, std::string> Shorthand::map{\n")
+    header_writer.write("const std::unordered_map<std::pair<uint32_t, uint32_t>, std::string, PairHash> Shorthand::map{\n")
     for e in entries:
         first = unicode.to_num(e.first)
         second = unicode.to_num(e.second)
-        assert first < 2 ** 24
-        assert second < 2 ** 8
-        key = (first << 8) | second
+        key = f"std::make_pair({first}, {second})"
         header_writer.write(f"    {{{key}, \"{e.result}\"}},\n")
     header_writer.write("};\n\n")
 

--- a/meta/typeset_shorthand.py
+++ b/meta/typeset_shorthand.py
@@ -25,27 +25,48 @@ def main():
 
     header_writer.write(
         "class Shorthand{\n"
-        "private:\n"
-        "    static const std::unordered_map<std::pair<uint32_t, uint32_t>, std::string, PairHash> map;\n"
-        "    static const std::string NONE;\n"
-        "\n"
         "public:\n"
-        "    static const std::string& lookup(uint32_t first, uint32_t second) noexcept{\n"
-        "        auto result = map.find(std::make_pair(first, second));\n"
-        "        return result==map.end() ? NONE : result->second;\n"
-        "    }\n"
+        "    static std::unordered_map<std::pair<uint32_t, uint32_t>, std::string, PairHash> map;\n"
+        "    static void reset();\n"
+        "    static const std::string& lookup(uint32_t first, uint32_t second) noexcept;\n"
+        "\n"
+        "private:\n"
+        "    static const std::unordered_map<std::pair<uint32_t, uint32_t>, std::string, PairHash> defaults;\n"
+        "    static const std::string NONE;\n"
         "};\n\n"
-        "const std::string Shorthand::NONE = \"\";\n\n"
     )
-    header_writer.write("const std::unordered_map<std::pair<uint32_t, uint32_t>, std::string, PairHash> Shorthand::map{\n")
-    for e in entries:
-        first = unicode.to_num(e.first)
-        second = unicode.to_num(e.second)
-        key = f"std::make_pair({first}, {second})"
-        header_writer.write(f"    {{{key}, \"{e.result}\"}},\n")
-    header_writer.write("};\n\n")
 
     header_writer.finalize()
+
+    with open("../src/generated/typeset_shorthand.cpp", "w", encoding="utf-8") as codegen_file:
+        codegen_file.write("#include \"typeset_shorthand.h\"\n\n")
+
+        codegen_file.write("namespace Hope {\n\n")
+        codegen_file.write("namespace Typeset {\n\n")
+
+        codegen_file.write("const std::string Shorthand::NONE = \"\";\n\n")
+
+        codegen_file.write(
+            "const std::unordered_map<std::pair<uint32_t, uint32_t>, std::string, PairHash> Shorthand::defaults{\n")
+        for e in entries:
+            first = unicode.to_num(e.first)
+            second = unicode.to_num(e.second)
+            key = f"std::make_pair({first}, {second})"
+            codegen_file.write(f"    {{{key}, \"{e.result}\"}},\n")
+        codegen_file.write("};\n\n")
+
+        codegen_file.write(
+            "void Shorthand::reset(){ map = defaults; }\n\n"
+            "const std::string& Shorthand::lookup(uint32_t first, uint32_t second) noexcept{\n"
+            "    auto result = map.find(std::make_pair(first, second));\n"
+            "    return result==map.end() ? NONE : result->second;\n"
+            "}\n\n"
+        )
+
+        codegen_file.write(
+            "std::unordered_map<std::pair<uint32_t, uint32_t>, std::string, PairHash> Shorthand::map = defaults;\n\n"
+            "}\n\n}\n"
+        )
 
 
 if __name__ == "__main__":

--- a/src/hope_common.h
+++ b/src/hope_common.h
@@ -1,0 +1,16 @@
+#ifndef HOPE_COMMON_H
+#define HOPE_COMMON_H
+
+#include <cinttypes>
+#include <limits>
+
+template<typename T, typename IN_TYPE>
+inline constexpr T debug_cast(IN_TYPE in) noexcept {
+    assert(dynamic_cast<T>(in));
+    return static_cast<T>(in);
+}
+
+typedef size_t ParseNode;
+extern inline constexpr size_t NONE = std::numeric_limits<size_t>::max();
+
+#endif // HOPE_COMMON_H

--- a/src/hope_common.h
+++ b/src/hope_common.h
@@ -1,7 +1,7 @@
 #ifndef HOPE_COMMON_H
 #define HOPE_COMMON_H
 
-#include <cinttypes>
+#include <cstddef>
 #include <limits>
 
 template<typename T, typename IN_TYPE>

--- a/src/hope_interpreter.cpp
+++ b/src/hope_interpreter.cpp
@@ -16,6 +16,9 @@ namespace Hope {
 
 namespace Code {
 
+Interpreter::Interpreter() noexcept
+    : error_node(NONE){}
+
 void Interpreter::run(const ParseTree& parse_tree, SymbolTable symbol_table, const InstantiationLookup& inst_lookup){
     assert(parse_tree.getOp(parse_tree.root) == OP_BLOCK);
     reset();
@@ -41,7 +44,7 @@ void Interpreter::stop(){
 
 void Interpreter::reset() noexcept {
     error_code = NO_ERROR_FOUND;
-    error_node = ParseTree::EMPTY;
+    error_node = NONE;
     directive = RUN;
     status = NORMAL;
     stack.clear();
@@ -761,7 +764,7 @@ Value Interpreter::anonFun(ParseNode pn){
 
     Closure* list = &l.closure;
 
-    initClosure(*list, ParseTree::EMPTY, ref_list);
+    initClosure(*list, NONE, ref_list);
 
     return l;
 }

--- a/src/hope_interpreter.h
+++ b/src/hope_interpreter.h
@@ -46,8 +46,9 @@ public:
     //These can be read from outside the interpreter
     Status status = NORMAL;
     ErrorCode error_code = NO_ERROR_FOUND;
-    ParseNode error_node = ParseTree::EMPTY;
+    ParseNode error_node;
 
+    Interpreter() noexcept;
     void run(const ParseTree& parse_tree, SymbolTable symbol_table, const InstantiationLookup& inst_lookup);
     void runThread(const ParseTree& parse_tree, SymbolTable symbol_table, const InstantiationLookup& inst_lookup);
     void stop();

--- a/src/hope_parse_tree.cpp
+++ b/src/hope_parse_tree.cpp
@@ -1,6 +1,7 @@
 #include "hope_parse_tree.h"
 
 #include <code_parsenode_ops.h>
+#include <hope_common.h>
 #include <hope_static_pass.h>
 #include "typeset_selection.h"
 
@@ -121,7 +122,7 @@ ParseNode ParseTree::algName(ParseNode node) const noexcept{
 }
 
 size_t ParseTree::valListSize(ParseNode node) const noexcept{
-    return node == EMPTY ? 0 : getNumArgs(node);
+    return node == NONE ? 0 : getNumArgs(node);
 }
 
 ParseNode ParseTree::unitVectorElem(ParseNode node) const noexcept{
@@ -157,7 +158,7 @@ size_t ParseTree::addTerminal(size_t type, const Typeset::Selection& c) alloc_ex
 
     resize(size() + FIXED_FIELDS);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setSelection(pn, c);
     setNumArgs(pn, 0);
 
@@ -169,7 +170,7 @@ size_t ParseTree::addUnary(size_t type, const Typeset::Selection& c, size_t chil
 
     resize(size() + FIXED_FIELDS + 1);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setSelection(pn, c);
     setNumArgs(pn, 1);
     setArg<0>(pn, child);
@@ -182,7 +183,7 @@ size_t ParseTree::addUnary(size_t type, size_t child) alloc_except {
 
     resize(size() + FIXED_FIELDS + 1);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setSelection(pn, getSelection(child));
     setNumArgs(pn, 1);
     setArg<0>(pn, child);
@@ -195,7 +196,7 @@ size_t ParseTree::addLeftUnary(size_t type, const Typeset::Marker& left, size_t 
 
     resize(size() + FIXED_FIELDS + 1);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setLeft(pn, left);
     setRight(pn, getRight(child));
     setNumArgs(pn, 1);
@@ -209,7 +210,7 @@ size_t ParseTree::addRightUnary(size_t type, const Typeset::Marker& right, size_
 
     resize(size() + FIXED_FIELDS + 1);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setLeft(pn, getLeft(child));
     setRight(pn, right);
     setNumArgs(pn, 1);
@@ -223,7 +224,7 @@ size_t ParseTree::addBinary(size_t type, const Typeset::Selection& c, size_t lhs
 
     resize(size() + FIXED_FIELDS + 2);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setSelection(pn, c);
     setNumArgs(pn, 2);
     setArg<0>(pn, lhs);
@@ -237,7 +238,7 @@ size_t ParseTree::addBinary(size_t type, size_t lhs, size_t rhs) alloc_except {
 
     resize(size() + FIXED_FIELDS + 2);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setLeft(pn, getLeft(lhs));
     setRight(pn, getRight(rhs));
     setNumArgs(pn, 2);
@@ -252,7 +253,7 @@ size_t ParseTree::addTernary(size_t type, const Typeset::Selection& c, size_t A,
 
     resize(size() + FIXED_FIELDS + 3);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setSelection(pn, c);
     setNumArgs(pn, 3);
     setArg<0>(pn, A);
@@ -267,7 +268,7 @@ ParseNode ParseTree::addTernary(Op type, ParseNode A, ParseNode B, ParseNode C) 
 
     resize(size() + FIXED_FIELDS + 3);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setLeft(pn, getLeft(A));
     setRight(pn, getRight(C));
     setNumArgs(pn, 3);
@@ -283,7 +284,7 @@ ParseNode ParseTree::addQuadary(Op type, ParseNode A, ParseNode B, ParseNode C, 
 
     resize(size() + FIXED_FIELDS + 4);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setLeft(pn, getLeft(A));
     setRight(pn, getRight(D));
     setNumArgs(pn, 4);
@@ -300,7 +301,7 @@ ParseNode ParseTree::addQuadary(Op type, const Typeset::Selection &c, ParseNode 
 
     resize(size() + FIXED_FIELDS + 4);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setSelection(pn, c);
     setNumArgs(pn, 4);
     setArg<0>(pn, A);
@@ -316,7 +317,7 @@ ParseNode ParseTree::addPentary(Op type, ParseNode A, ParseNode B, ParseNode C, 
 
     resize(size() + FIXED_FIELDS + 5);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setLeft(pn, getLeft(A));
     setRight(pn, getRight(E));
     setNumArgs(pn, 5);
@@ -334,7 +335,7 @@ ParseNode ParseTree::addPentary(Op type, const Typeset::Selection& c, ParseNode 
 
     resize(size() + FIXED_FIELDS + 5);
     setOp(pn, type);
-    setFlag(pn, EMPTY);
+    setFlag(pn, NONE);
     setSelection(pn, c);
     setNumArgs(pn, 5);
     setArg<0>(pn, A);
@@ -363,8 +364,8 @@ ParseNode ParseTree::clone(ParseNode pn) alloc_except {
     resize(size() + nargs);
     for(size_t i = 0; i < nargs; i++){
         ParseNode a = arg(pn, i);
-        if(a == EMPTY){
-            setArg(cloned, i, EMPTY);
+        if(a == NONE){
+            setArg(cloned, i, NONE);
         }else{
             setArg(cloned, i, clone(a));
         }
@@ -500,7 +501,7 @@ void ParseTree::graphvizHelper(std::string& src, ParseNode n, size_t& size) cons
     src += "]\n";
     for(size_t i = 0; i < getNumArgs(n); i++){
         size_t child = arg(n, i);
-        if(child != EMPTY){
+        if(child != NONE){
             std::string child_id = std::to_string(size);
             graphvizHelper(src, child, size);
             src += "\tn" + id + "->n" + child_id + "\n";
@@ -526,7 +527,7 @@ size_t ParseTree::NaryBuilder::finalize() alloc_except {
 
     tree.resize(tree.size() + FIXED_FIELDS);
     tree.setOp(pn, type);
-    tree.setFlag(pn, EMPTY);
+    tree.setFlag(pn, NONE);
     tree.setLeft(pn, tree.getLeft(children.front()));
     tree.setRight(pn, tree.getRight(children.back()));
     tree.setNumArgs(pn, children.size());
@@ -545,7 +546,7 @@ size_t ParseTree::NaryBuilder::finalize(const Typeset::Marker& right) alloc_exce
 
     tree.resize(tree.size() + FIXED_FIELDS);
     tree.setOp(pn, type);
-    tree.setFlag(pn, EMPTY);
+    tree.setFlag(pn, NONE);
     tree.setLeft(pn, tree.getLeft(children.front()));
     tree.setRight(pn, right);
     tree.setNumArgs(pn, children.size());
@@ -564,7 +565,7 @@ size_t ParseTree::NaryBuilder::finalize(const Typeset::Selection& c) alloc_excep
 
     tree.resize(tree.size() + FIXED_FIELDS);
     tree.setOp(pn, type);
-    tree.setFlag(pn, EMPTY);
+    tree.setFlag(pn, NONE);
     tree.setSelection(pn, c);
     tree.setNumArgs(pn, children.size());
     tree.insert(tree.end(), children.begin(), children.end());

--- a/src/hope_parse_tree.h
+++ b/src/hope_parse_tree.h
@@ -17,8 +17,6 @@ struct Marker;
 
 namespace Code {
 
-typedef size_t ParseNode;
-
 class ParseTree : private std::vector<size_t> {
 public:
     HOPE_AST_FIELD_CODEGEN_DECLARATIONS
@@ -88,8 +86,6 @@ public:
     #endif
 
     size_t root;
-
-    static constexpr ParseNode EMPTY = std::numeric_limits<size_t>::max();
 
     class NaryBuilder{
     public:

--- a/src/hope_parser.h
+++ b/src/hope_parser.h
@@ -41,9 +41,9 @@ private:
     ParseNode plotStatement() alloc_except;
     ParseNode mathStatement() alloc_except;
     ParseNode namedLambdaStmt(ParseNode call) alloc_except;
-    ParseNode assignment(const ParseNode& lhs) alloc_except;
+    ParseNode assignment(ParseNode lhs) alloc_except;
     ParseNode expression() alloc_except;
-    ParseNode equality(const ParseNode& lhs) alloc_except;
+    ParseNode equality(ParseNode lhs) alloc_except;
     ParseNode disjunction() alloc_except;
     ParseNode conjunction() alloc_except;
     ParseNode comparison() alloc_except;
@@ -66,15 +66,15 @@ private:
     ParseNode identifierFollowOn(ParseNode id) alloc_except;
     ParseNode isolatedIdentifier() alloc_except;
     ParseNode param() alloc_except;
-    ParseNode call(const ParseNode& id) alloc_except;
-    ParseNode lambda(const ParseNode& params) alloc_except;
+    ParseNode call(ParseNode id) alloc_except;
+    ParseNode lambda(ParseNode params) alloc_except;
     ParseNode fraction() alloc_except;
     ParseNode fractionDeriv(const Typeset::Selection& c, Op type, TokenType tt) alloc_except;
     ParseNode fractionDefault(const Typeset::Selection& c) alloc_except;
     ParseNode binomial() alloc_except;
-    ParseNode superscript(const ParseNode& lhs) alloc_except;
-    ParseNode subscript(const ParseNode& lhs, const Typeset::Marker& right) alloc_except;
-    ParseNode dualscript(const ParseNode& lhs) alloc_except;
+    ParseNode superscript(ParseNode lhs) alloc_except;
+    ParseNode subscript(ParseNode lhs, const Typeset::Marker& right) alloc_except;
+    ParseNode dualscript(ParseNode lhs) alloc_except;
     ParseNode subExpr() alloc_except;
     ParseNode matrix() alloc_except;
     ParseNode cases() alloc_except;
@@ -108,6 +108,8 @@ private:
     const Typeset::Marker& rMark() const noexcept;
     const Typeset::Marker& lMarkPrev() const noexcept;
     const Typeset::Marker& rMarkPrev() const noexcept;
+    bool noErrors() const noexcept;
+    void recover() noexcept;
 
     const std::vector<Token>& tokens;
     std::vector<Error>& errors;
@@ -115,18 +117,7 @@ private:
     size_t index = 0;
     bool parsing_dims = false;
     size_t loops = 0;
-
-    static constexpr size_t UNITIALIZED = std::numeric_limits<size_t>::max();
-    size_t error_node = UNITIALIZED;
-
-    bool noErrors() const noexcept{
-        return error_node == UNITIALIZED;
-    }
-
-    void recover() noexcept{
-        error_node = UNITIALIZED;
-        index = tokens.size()-1; //Give up for now
-    }
+    size_t error_node;
 };
 
 }

--- a/src/hope_static_pass.cpp
+++ b/src/hope_static_pass.cpp
@@ -85,7 +85,7 @@ void StaticPass::reset() noexcept{
 ParseNode StaticPass::resolveStmt(size_t pn) noexcept{
     if(!errors.empty()) return pn;
 
-    assert(pn != ParseTree::EMPTY);
+    assert(pn != NONE);
 
     switch (parse_tree.getOp(pn)) {
         case OP_ASSIGN:
@@ -349,7 +349,7 @@ ParseNode StaticPass::resolveExprTop(size_t pn, size_t rows_expected, size_t col
 }
 
 ParseNode StaticPass::resolveExpr(size_t pn, size_t rows_expected, size_t cols_expected) noexcept{
-    assert(pn != ParseTree::EMPTY);
+    assert(pn != NONE);
 
     if(rows_expected == UNKNOWN_SIZE) rows_expected = parse_tree.getRows(pn);
     if(cols_expected == UNKNOWN_SIZE) cols_expected = parse_tree.getCols(pn);
@@ -1572,7 +1572,7 @@ Type StaticPass::instantiate(ParseNode call_node, const CallSignature& fn){
     size_t old_args_index = old_args.size();
 
     //Instantiate
-    called_func_map[fn] = CallResult(RECURSIVE_CYCLE, UNKNOWN_SIZE, UNKNOWN_SIZE, ParseTree::EMPTY);
+    called_func_map[fn] = CallResult(RECURSIVE_CYCLE, UNKNOWN_SIZE, UNKNOWN_SIZE, NONE);
 
     ParseNode instantiated_fn = parse_tree.clone(abstract_fn);
 
@@ -1582,7 +1582,7 @@ Type StaticPass::instantiate(ParseNode call_node, const CallSignature& fn){
     size_t N_vals = parse_tree.valListSize(val_list);
 
     size_t type_index = 0;
-    if(val_list != ParseTree::EMPTY){
+    if(val_list != NONE){
         size_t scope_index = parse_tree.getFlag(val_list);
         const ScopeSegment& scope = symbol_table.scopes[scope_index];
         for(size_t i = 0; i < N_vals; i++){

--- a/src/hope_symbol_build_pass.cpp
+++ b/src/hope_symbol_build_pass.cpp
@@ -1,6 +1,7 @@
 #include "hope_symbol_build_pass.h"
 
 #include <code_parsenode_ops.h>
+#include <hope_common.h>
 #include "typeset_model.h"
 #include <algorithm>
 #include <cassert>
@@ -492,7 +493,7 @@ void SymbolTableBuilder::resolveAlgorithm(ParseNode pn) alloc_except {
                 errors.push_back(Error(sel, TYPE_ERROR));
             }
         }else if(sym.declaration_lexical_depth == lexical_depth){
-            appendEntry(index, name, lookup->second, true);
+            appendEntry(name, lookup->second, true);
             lookup->second = symbol_table.symbols.size()-1;
         }
 
@@ -500,7 +501,7 @@ void SymbolTableBuilder::resolveAlgorithm(ParseNode pn) alloc_except {
     }
 
     size_t val_cap_size = parse_tree.valListSize(val_cap);
-    if(val_cap != ParseTree::EMPTY){
+    if(val_cap != NONE){
         parse_tree.setFlag(val_cap, symbol_table.scopes.size());
         for(size_t i = 0; i < val_cap_size; i++){
             ParseNode capture = parse_tree.arg(val_cap, i);
@@ -632,7 +633,7 @@ bool SymbolTableBuilder::defineLocalScope(ParseNode pn, bool immutable) alloc_ex
             errors.push_back(Error(c, CONST ? REASSIGN_CONSTANT : MUTABLE_CONST_ASSIGN));
             return false;
         }else{
-            appendEntry(index, pn, lookup->second, immutable);
+            appendEntry(pn, lookup->second, immutable);
             lookup->second = symbol_table.symbols.size()-1;
         }
     }
@@ -739,7 +740,7 @@ void SymbolTableBuilder::makeEntry(const Typeset::Selection& c, ParseNode pn, bo
     symbol_table.addSymbol(pn, lexical_depth, closure_depth, NONE, immutable);
 }
 
-void SymbolTableBuilder::appendEntry(size_t index, ParseNode pn, size_t prev, bool immutable) alloc_except {
+void SymbolTableBuilder::appendEntry(ParseNode pn, size_t prev, bool immutable) alloc_except {
     warnings.push_back(Error(parse_tree.getSelection(pn), SHADOWING_VAR)); //EVENTUALLY: make this optional, probably default off
     symbol_table.usages.push_back(Usage(symbol_table.symbols.size(), pn, DECLARE));
     symbol_table.addSymbol(pn, lexical_depth, closure_depth, prev, immutable);

--- a/src/hope_symbol_build_pass.h
+++ b/src/hope_symbol_build_pass.h
@@ -49,7 +49,7 @@ private:
     void increaseClosureDepth(const Typeset::Selection& name, const Typeset::Marker& begin, ParseNode pn) alloc_except;
     void decreaseClosureDepth(const Typeset::Marker& end) alloc_except;
     void makeEntry(const Typeset::Selection& c, ParseNode pn, bool immutable) alloc_except;
-    void appendEntry(size_t index, ParseNode pn, size_t prev, bool immutable) alloc_except;
+    void appendEntry(ParseNode pn, size_t prev, bool immutable) alloc_except;
     void resolveStmt(ParseNode pn) alloc_except;
     void resolveExpr(ParseNode pn) alloc_except;
     void resolveEquality(ParseNode pn) alloc_except;

--- a/src/hope_symbol_table.h
+++ b/src/hope_symbol_table.h
@@ -1,6 +1,7 @@
 #ifndef HOPE_SCOPE_TREE_H
 #define HOPE_SCOPE_TREE_H
 
+#include <hope_common.h>
 #include "typeset_selection.h"
 #include "typeset_text.h"
 #include <limits>
@@ -16,8 +17,6 @@ namespace Code {
 
 class ParseTree;
 
-static constexpr size_t NONE = std::numeric_limits<size_t>::max();
-typedef size_t ParseNode;
 typedef size_t ScopeId;
 typedef size_t SymbolId;
 static constexpr size_t UNKNOWN_SIZE = 0;

--- a/src/hope_unicode.h
+++ b/src/hope_unicode.h
@@ -65,7 +65,7 @@ static uint32_t expand(char ch) noexcept{
     return static_cast<uint32_t>(static_cast<uint8_t>(ch));
 }
 
-inline uint32_t codepointInt(const std::string& str, size_t index){
+inline uint32_t codepointInt(const std::string& str, size_t index = 0) noexcept {
     assert(index < str.size());
 
     uint8_t ch = str[index];
@@ -87,7 +87,12 @@ inline uint32_t codepointInt(const std::string& str, size_t index){
     }
 }
 
-inline size_t graphemeSize(const std::string& str, size_t index){
+inline bool isSingleCodepoint(const std::string& str) noexcept {
+    if(str.empty()) return false;
+    return codepointSize(str[0]) == (str.size() - (str.back() == '\0'));
+}
+
+inline size_t graphemeSize(const std::string& str, size_t index) noexcept {
     assert(index < str.size());
 
     size_t start = index;
@@ -98,7 +103,7 @@ inline size_t graphemeSize(const std::string& str, size_t index){
     return index - start;
 }
 
-inline size_t graphemeSizeLeft(const std::string& str, size_t index){
+inline size_t graphemeSizeLeft(const std::string& str, size_t index) noexcept {
     size_t end = index;
 
     do {
@@ -109,7 +114,22 @@ inline size_t graphemeSizeLeft(const std::string& str, size_t index){
     return end-index;
 }
 
-inline constexpr uint32_t constructScannerCode(uint32_t code) noexcept{
+inline std::string fromCode(uint32_t code){
+    std::string str;
+    str += static_cast<uint8_t>(code);
+
+    if(code & (1 << 7)){
+        str += static_cast<uint8_t>(code >> 8);
+        if(code & (1 << 6)){
+            str += static_cast<uint8_t>(code >> 16);
+            if(code & (1 << 5)) str += static_cast<uint8_t>(code >> 24);
+        }
+    }
+
+    return str;
+}
+
+inline constexpr uint32_t constructScannerCode(uint32_t code) noexcept {
     uint32_t val = static_cast<uint32_t>(1 << 7) | code;
     assert(isContinuationCharacter(val));
     //Map constructs to continuation characters since they are free

--- a/src/typeset_construct.cpp
+++ b/src/typeset_construct.cpp
@@ -185,10 +185,36 @@ double Construct::height() const noexcept{
     return above_center + under_center;
 }
 
+Construct::ContextAction::ContextAction(const std::string& name, void (*takeAction)(Construct*, Controller&, Subphrase*))
+    : takeAction(takeAction), name(name) {}
+
 const std::vector<Construct::ContextAction> Construct::no_actions {};
 
 const std::vector<Construct::ContextAction>& Construct::getContextActions(Subphrase*) const noexcept{
     return no_actions;
+}
+
+void Construct::updateChildPositions(){
+    // Default does nothing
+    // Must override for constructs with children
+    assert(numArgs() == 0);
+}
+
+void Construct::paintSpecific(Painter&) const {
+    // Default does nothing
+}
+
+void Construct::invalidateX() noexcept{
+    x = std::numeric_limits<double>::quiet_NaN();
+}
+
+void Construct::invalidateY() noexcept{
+    y = std::numeric_limits<double>::quiet_NaN();
+}
+
+void Construct::invalidatePos() noexcept{
+    invalidateX();
+    invalidateY();
 }
 #endif
 

--- a/src/typeset_construct.h
+++ b/src/typeset_construct.h
@@ -89,8 +89,7 @@ public:
         const std::string name;
 
         ContextAction(const std::string& name,
-                      void(*takeAction)(Construct* con, Controller& c, Subphrase* child))
-            : takeAction(takeAction), name(name) {}
+                      void(*takeAction)(Construct* con, Controller& c, Subphrase* child));
     };
 
     static const std::vector<ContextAction> no_actions;
@@ -108,9 +107,12 @@ protected:
     Subphrase* second() const noexcept;
 
     #ifndef HOPE_TYPESET_HEADLESS
-    virtual void updateSizeSpecific() noexcept { /*IMPLEMENT MEEEE*/ }
-    virtual void updateChildPositions(){ /*IMPLEMENT MEEEE*/ }
-    virtual void paintSpecific(Painter&) const { /*DO NOTHING*/ }
+    virtual void updateSizeSpecific() noexcept = 0;
+    virtual void updateChildPositions();
+    virtual void paintSpecific(Painter&) const;
+    virtual void invalidateX() noexcept;
+    virtual void invalidateY() noexcept;
+    virtual void invalidatePos() noexcept;
     #endif
 
     std::vector<Subphrase*> args;

--- a/src/typeset_controller.cpp
+++ b/src/typeset_controller.cpp
@@ -454,7 +454,7 @@ void Controller::keystroke(const std::string& str){
         return;
     }else if(str == " "){
         std::string_view word = active.checkKeyword();
-        const std::string& sub = Keywords::lookup(word);
+        const std::string& sub = Keywords::lookup(std::string(word));
         insertText(str);
 
         if(!sub.empty()){

--- a/src/typeset_model.cpp
+++ b/src/typeset_model.cpp
@@ -549,14 +549,13 @@ void Model::clearFormatting() noexcept{
 }
 
 void Model::performSemanticFormatting(){
-    clearFormatting();
+    if(is_output) return;
 
+    clearFormatting();    
     scanner.scanAll();
-    if(!is_output){
-        parser.parseAll();
-        symbol_builder.resolveSymbols();
-        static_pass.resolve();
-    }
+    parser.parseAll();
+    symbol_builder.resolveSymbols();
+    static_pass.resolve();
 }
 
 void Model::premutate() noexcept{

--- a/src/typeset_text.cpp
+++ b/src/typeset_text.cpp
@@ -266,6 +266,12 @@ void Text::updateWidth(){
         type = tag.type;
     }
     width += Hope::Typeset::getWidth(type, depth, str.substr(start));
+
+    invalidateX();
+}
+
+void Text::invalidateX() noexcept {
+    x = std::numeric_limits<double>::quiet_NaN();
 }
 
 double Text::xLocal(size_t index) const{

--- a/src/typeset_text.h
+++ b/src/typeset_text.h
@@ -73,6 +73,7 @@ class Text {
         double underCenter() const;
         double height() const;
         void updateWidth();
+        void invalidateX() noexcept;
         double xLocal(size_t index) const;
         double xPhrase(size_t index) const;
         double xGlobal(size_t index) const;

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -521,7 +521,7 @@ void View::resolveTooltip(double x, double y) noexcept{
             const auto& symbol = symbol_table.symbols[lookup->second];
             QString tooltip = "<b>" + QString::fromStdString(c.selectedText()) + "</b> ∈ "
                     + QString::fromStdString(model->static_pass.typeString(symbol));
-            if(symbol.comment != Code::ParseTree::EMPTY)
+            if(symbol.comment != NONE)
                 tooltip += "<div style=\"color:green\">" + QString::fromStdString(symbol_table.parse_tree.str(symbol.comment));
             setToolTip(tooltip);
             return;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(GEN_FILES
     ${GEN}/typeset_closesymbol.h
     ${GEN}/typeset_keywords.cpp
     ${GEN}/typeset_keywords.h
+    ${GEN}/typeset_shorthand.cpp
     ${GEN}/typeset_shorthand.h
     ${GEN}/typeset_themes.cpp
     ${GEN}/typeset_themes.h
@@ -120,6 +121,7 @@ set(SOURCES
     ${TEST}/typeset_mutability.h
     ${GEN_FILES}
     ${CONSTRUCT_FILES}
+    ${SRC}/hope_common.h
     ${SRC}/hope_error.cpp
     ${INCLUDE}/hope_error.h
     ${SRC}/hope_interpreter.cpp


### PR DESCRIPTION
The primary goal of this MR is to allow custimisation of editor commands, both keyword commands beginning with '\\' and symbol shortcuts such as typing "=/" being substituted to '≠'. The secondary goal is to improve the typesetting architecture, and as such being finished is a bit of a moving target. The first goal is accomplished, at least.