### PR TITLE
Save keywords as list

### DIFF
--- a/example/exampleWidgetQt/keywordsubstitutioneditor.h
+++ b/example/exampleWidgetQt/keywordsubstitutioneditor.h
@@ -33,7 +33,7 @@ private:
 
     KeywordSubstitutionLabel* getButtonLabel() const;
     ModifiedLineEdit* getBottomEdit() const;
-    void populateDefaults();
+    void populateWidgetFromMap();
     void load();
     void addRowForEntry(const std::string& keyword, const std::string& result);
     static std::vector<std::pair<std::string, std::string>> getSortedMap();


### PR DESCRIPTION
My Ubuntu VM setup took issue to derefencing a QMap iterator, but really this is an opportunity to clean that up a bit, since it can be saved as an unsorted list.