### PR TITLE
Honour saved window maximisation

### DIFF
--- a/example/exampleWidgetQt/CMakeLists.txt
+++ b/example/exampleWidgetQt/CMakeLists.txt
@@ -262,21 +262,19 @@ if(QT_VERSION_MAJOR EQUAL 6)
 endif()
 
 add_compile_definitions($<$<CONFIG:Release>:EIGEN_NO_DEBUG>)
-#EVENTUALLY: get rid of EIGEN_UNSUPPORTED macro and only accept compilers that can handle it
 
 if(MSVC)
     target_compile_options(Forscape PRIVATE
         /Ob3 /W3 #/WX #EVENTUALLY: address warnings
         $<$<CONFIG:Release>:/Oi /Oy>
-        $<$<CONFIG:Debug>:/bigobj>
-        #/bigobj #May be needed to make Eigen unsupported compile
+        $<$<CONFIG:Debug>:/bigobj> #Often needed to make Eigen unsupported compile
     )
     target_link_options(Forscape PRIVATE
         $<$<CONFIG:Release>:/OPT:REF>
     )
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(Forscape PRIVATE
-        $<$<CONFIG:Debug>:-O2> #Need optimisation for MinGW to compile w/ Eigen unsupported
+        $<$<CONFIG:Debug>:-O1> #Need optimisation for MinGW to compile w/ Eigen unsupported
         -Wall -Wextra -pedantic #-Werror #EVENTUALLY: address warnings
         $<$<CONFIG:Release>: -Ofast -fmodulo-sched -fmodulo-sched-allow-regmoves -fgcse-sm -fgcse-las -fdelete-null-pointer-checks
         -fomit-frame-pointer -funroll-loops> #-fwhole-program #EVENTUALLY: couldn't get whole program optimisation working

--- a/example/exampleWidgetQt/installer/packages/com.automath.forscape/meta/package.xml
+++ b/example/exampleWidgetQt/installer/packages/com.automath.forscape/meta/package.xml
@@ -3,7 +3,7 @@
     <DisplayName>Forscape</DisplayName>
     <Description>Core</Description>
     <Version>0.0.1</Version>
-    <ReleaseDate>2010-09-21</ReleaseDate>
+    <ReleaseDate>2022-05-29</ReleaseDate>
     <Licenses>
         <License name="MIT License" file="LICENSE" />
     </Licenses>

--- a/example/exampleWidgetQt/main.cpp
+++ b/example/exampleWidgetQt/main.cpp
@@ -16,9 +16,7 @@ int main(int argc, char* argv[]){
     Hope::logger->info("/* APP_SESSION_START */");
     Hope::Typeset::setPreset(Hope::Typeset::PRESET_DEFAULT);
     MainWindow w;
-
     w.show();
-    w.resize(w.width()+1, w.height()+1);
     auto code = a.exec();
     Hope::logger->info("/* APP_SESSION_END */");
 

--- a/example/exampleWidgetQt/mainwindow.h
+++ b/example/exampleWidgetQt/mainwindow.h
@@ -43,6 +43,8 @@ private:
     static constexpr std::chrono::milliseconds INTERPETER_POLL_PERIOD = std::chrono::milliseconds(15);
     bool editor_had_focus;
     bool unsaved_changes = false;
+    void loadGeometry();
+    void resizeHackToFixScrollbars();
     bool isSavedDeepComparison() const;
 
 private slots:

--- a/src/typeset_painter_qt.cpp
+++ b/src/typeset_painter_qt.cpp
@@ -121,7 +121,7 @@ void Painter::setOffset(double x, double y){
 
 void Painter::drawText(double x, double y, std::string_view text, bool forward){
     x += x_offset;
-    QString q_str = QString::fromUtf8(text.data(), text.size());
+    QString q_str = QString::fromUtf8(text.data(), static_cast<int>(text.size()));
 
     if(forward){
         y += CAPHEIGHT[depth];
@@ -150,7 +150,7 @@ void Painter::drawHighlightedGrouping(double x, double y, double w, std::string_
 
     painter.setPen(getColour(COLOUR_GROUPINGHIGHLIGHT));
     y += CAPHEIGHT[depth];
-    painter.drawText(x, y, QString::fromUtf8(text.data(), text.size()));
+    painter.drawText(x, y, QString::fromUtf8(text.data(), static_cast<int>(text.size())));
 
     painter.setPen(getColour(COLOUR_CURSOR));
     painter.setBrush(getColour(COLOUR_CURSOR));
@@ -159,7 +159,7 @@ void Painter::drawHighlightedGrouping(double x, double y, double w, std::string_
 void Painter::drawSymbol(double x, double y, std::string_view text){
     x += x_offset;
     y += CAPHEIGHT[depth];
-    painter.drawText(x, y, QString::fromUtf8(text.data(), text.size()));
+    painter.drawText(x, y, QString::fromUtf8(text.data(), static_cast<int>(text.size())));
 }
 
 void Painter::drawLine(double x, double y, double w, double h){
@@ -333,7 +333,7 @@ void Painter::drawSymbol(char ch, double x, double y, double w, double h){
 void Painter::drawSymbol(std::string_view str, double x, double y, double w, double h){
     x += x_offset;
 
-    QString qstr = QString::fromUtf8(str.data(), str.size());
+    QString qstr = QString::fromUtf8(str.data(), static_cast<int>(str.size()));
     double scale_x = w / CHARACTER_WIDTHS[depth]*qstr.size();
     double scale_y = h / ASCENT[depth];
     x /= scale_x;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -221,14 +221,12 @@ endif ()
 add_test(NAME IntegrationTest COMMAND HopeTests.exe)
 
 add_compile_definitions($<$<CONFIG:Release>:EIGEN_NO_DEBUG>)
-#EVENTUALLY: get rid of EIGEN_UNSUPPORTED macro and only accept compilers that can handle it
 
 if(MSVC)
     target_compile_options(HopeTests PRIVATE
         /Ob3 /W3 #/WX #EVENTUALLY: address warnings
         $<$<CONFIG:Release>:/Oi /Oy> #/GL
-        $<$<CONFIG:Debug>:/bigobj>
-        #/bigobj #May be needed to make Eigen unsupported compile
+        $<$<CONFIG:Debug>:/bigobj> #Often needed to make Eigen unsupported compile
     )
     target_link_options(HopeTests PRIVATE
         $<$<CONFIG:Release>:/OPT:REF> #/LTCG


### PR DESCRIPTION
The hack to fix the initial scrollbar positioning was interfering with starting the app in a maximised state. Now the hack is only applied if the window was not maximised.