### PR TITLE
Typing suggestions for files and module variables

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -397,7 +397,7 @@ void MainWindow::stop(){
 }
 
 void MainWindow::pollInterpreterThread(){
-    auto& interpreter = editor->getModel()->interpreter;
+    auto& interpreter = Program::instance()->program_entry_point->interpreter;
 
     if(interpreter.status == Forscape::Code::Interpreter::FINISHED){
         checkOutput();
@@ -505,7 +505,7 @@ void MainWindow::on_actionExit_triggered(){
 }
 
 void MainWindow::checkOutput(){
-    auto& interpreter = editor->getModel()->interpreter;
+    auto& interpreter = Program::instance()->program_entry_point->interpreter;
     auto& message_queue = interpreter.message_queue;
 
     static std::string print_buffer;

--- a/meta/errors.csv
+++ b/meta/errors.csv
@@ -84,3 +84,4 @@ FILE_CORRUPTED,,File contains invalid encoding
 SELF_IMPORT,,Self import not allowed
 NOT_IMPLEMENTED,,Import statements are not supported yet
 IMPORT_FIELD_NOT_FOUND,y,Variable does not exist in global scope of file
+ERROR_IN_LOADED_FILE,,Imported file contains an error

--- a/meta/errors.csv
+++ b/meta/errors.csv
@@ -83,3 +83,4 @@ EXPECTED_FILEPATH,,Expected filepath
 FILE_CORRUPTED,,File contains invalid encoding
 SELF_IMPORT,,Self import not allowed
 NOT_IMPLEMENTED,,Import statements are not supported yet
+IMPORT_FIELD_NOT_FOUND,y,Variable does not exist in global scope of file

--- a/src/forscape_parse_tree.cpp
+++ b/src/forscape_parse_tree.cpp
@@ -425,6 +425,7 @@ void ParseTree::shift(ParseNode pn, size_t offset) {
 
     //EVENTUALLY: the adhoc flag wrangling comes back to haunt you
     // (although it's haunting you during adhoc tree grafting)
+    // Anywhere a ParseNode is implicitly in the tree, you'll have a bad time
     switch (getOp(pn)) {
         case OP_SINGLE_CHAR_MULT_PROXY:
         case OP_IMPORT:

--- a/src/forscape_parse_tree.cpp
+++ b/src/forscape_parse_tree.cpp
@@ -422,6 +422,17 @@ void ParseTree::shift(ParseNode pn, size_t offset) {
     #ifndef NDEBUG
     created.insert(pn);
     #endif
+
+    //EVENTUALLY: the adhoc flag wrangling comes back to haunt you
+    // (although it's haunting you during adhoc tree grafting)
+    switch (getOp(pn)) {
+        case OP_SINGLE_CHAR_MULT_PROXY:
+        case OP_IMPORT:
+            setFlag(pn, getFlag(pn)+offset);
+            shift(getFlag(pn), offset);
+            break;
+    }
+
     for(size_t i = getNumArgs(pn); i-->0;){
         ParseNode old_arg = arg(pn, i);
         if(old_arg == NONE) continue;

--- a/src/forscape_program.h
+++ b/src/forscape_program.h
@@ -26,7 +26,7 @@ public:
     void reset() noexcept;
     void runStaticPass();
     void getFileSuggestions(std::vector<std::string>& suggestions) const;
-    void getFileSuggestions(std::vector<std::string>& suggestions, std::string_view base) const;
+    void getFileSuggestions(std::vector<std::string>& suggestions, std::string_view input) const;
 
     FORSCAPE_UNORDERED_MAP<std::filesystem::path, Typeset::Model*> source_files; //May contain multiple entries per model
     std::vector<Code::Error> errors;

--- a/src/forscape_program.h
+++ b/src/forscape_program.h
@@ -25,6 +25,8 @@ public:
     void clearPendingProjectBrowserUpdates() noexcept;
     void reset() noexcept;
     void runStaticPass();
+    void getFileSuggestions(std::vector<std::string>& suggestions) const;
+    void getFileSuggestions(std::vector<std::string>& suggestions, std::string_view base) const;
 
     FORSCAPE_UNORDERED_MAP<std::filesystem::path, Typeset::Model*> source_files; //May contain multiple entries per model
     std::vector<Code::Error> errors;

--- a/src/forscape_static_pass.cpp
+++ b/src/forscape_static_pass.cpp
@@ -414,7 +414,8 @@ ParseNode StaticPass::resolveStmt(ParseNode pn) noexcept{
                 auto lookup = lexical_map.find(parse_tree.getSelection(imported_var));
                 if(lookup == lexical_map.end()){
                     parse_tree.setOp(imported_var, OP_ERROR);
-                    return error(pn, pn, BAD_READ);
+                    parse_tree.setFlag(imported_var, reinterpret_cast<size_t>(&lexical_map));
+                    return error(pn, imported_var, IMPORT_FIELD_NOT_FOUND);
                 }
 
                 Symbol& sym = *reinterpret_cast<Symbol*>(lookup->second);

--- a/src/forscape_symbol_table.h
+++ b/src/forscape_symbol_table.h
@@ -136,7 +136,7 @@ public:
 
     void addSymbol(size_t pn, size_t lexical_depth, size_t closure_depth, size_t shadowed, bool is_const) alloc_except;
     size_t containingScope(const Typeset::Marker& m) const noexcept;
-    std::vector<std::string> getSuggestions(const Typeset::Marker& loc) const;
+    void getSuggestions(const Typeset::Marker& loc, std::vector<std::string>& suggestions) const;
     const Typeset::Selection& getSel(size_t sym_index) const noexcept;
 
     void reset(const Typeset::Marker& doc_start) noexcept;

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -1654,22 +1654,30 @@ void Editor::populateSuggestions() {
 
     for(const Code::Error& err : model->errors){
         if(err.code == Code::EXPECTED_FILEPATH && err.selection.left == controller.anchor){
+            //Just about to type a filename
             recommend_without_hint = true;
             Program::instance()->getFileSuggestions(suggestions);
+            std::sort(suggestions.begin(), suggestions.end());
+            suggestions.erase(std::unique(suggestions.begin(), suggestions.end()), suggestions.end());
             return;
         }else if(err.code == Code::FILE_NOT_FOUND && err.selection.right == controller.anchor){
+            //In the process of typing a filename
             if(!err.selection.isTextSelection()) return;
             filename_start = &err.selection.left;
             Program::instance()->getFileSuggestions(suggestions, err.selection.strView());
+            std::sort(suggestions.begin(), suggestions.end());
+            suggestions.erase(std::unique(suggestions.begin(), suggestions.end()), suggestions.end());
             return;
         }else if(err.code == Code::IMPORT_FIELD_NOT_FOUND && err.selection.right == controller.anchor){
+            //In the process of typing an external module variable
             const Typeset::Marker& left = err.selection.left;
             ParseNode err_node = left.text->parseNodeAtIndex(left.index);
             size_t flag = parseTree().getFlag(err_node);
-            const auto& map = *reinterpret_cast<FORSCAPE_UNORDERED_MAP<Typeset::Selection, size_t>*>(flag);
-            for(const auto& entry : map)
+            const auto& lexical_map = *reinterpret_cast<FORSCAPE_UNORDERED_MAP<Typeset::Selection, size_t>*>(flag);
+            for(const auto& entry : lexical_map)
                 if(entry.first.startsWith(err.selection))
                     suggestions.push_back(entry.first.str());
+            std::sort(suggestions.begin(), suggestions.end());
             return;
         }
     }

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -1662,10 +1662,19 @@ void Editor::populateSuggestions() {
             filename_start = &err.selection.left;
             Program::instance()->getFileSuggestions(suggestions, err.selection.strView());
             return;
+        }else if(err.code == Code::IMPORT_FIELD_NOT_FOUND && err.selection.right == controller.anchor){
+            const Typeset::Marker& left = err.selection.left;
+            ParseNode err_node = left.text->parseNodeAtIndex(left.index);
+            size_t flag = parseTree().getFlag(err_node);
+            const auto& map = *reinterpret_cast<FORSCAPE_UNORDERED_MAP<Typeset::Selection, size_t>*>(flag);
+            for(const auto& entry : map)
+                if(entry.first.startsWith(err.selection))
+                    suggestions.push_back(entry.first.str());
+            return;
         }
     }
 
-    suggestions = model->symbol_builder.symbol_table.getSuggestions(controller.active);
+    model->symbol_builder.symbol_table.getSuggestions(controller.active, suggestions);
 }
 
 void Editor::takeRecommendation(const std::string& str){

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -835,7 +835,7 @@ void View::drawModel(double xL, double yT, double xR, double yB) {
 
     #ifndef NDEBUG
     if(hover_node != NONE){
-        const Typeset::Selection& sel = parseTree().getSelection(hover_node);
+        const Typeset::Selection& sel = model->parser.parse_tree.getSelection(hover_node);
         sel.paintHighlight(painter);
     }
     #endif
@@ -1437,7 +1437,6 @@ void Editor::resolveTooltip(double x, double y) noexcept {
     }
 
     hover_node = model->parseNodeAt(x, y);
-    if(hover_node != NONE) hover_node += model->parse_node_offset;
     #ifndef NDEBUG
     if(hover_node == NONE) clearTooltip();
     #else
@@ -1559,9 +1558,10 @@ void Editor::goToFile() {
 }
 
 void Editor::showTooltipParseNode(){
-    assert(hover_node != NONE);
+    assert(this->hover_node != NONE);
 
     const auto& parse_tree = parseTree();
+    const ParseNode hover_node = this->hover_node + model->parse_node_offset;
     switch(parse_tree.getOp(hover_node)){
         case Code::OP_IDENTIFIER:{
             if(!model->errors.empty()) return; //EVENTUALLY: this is a bit strict. would rather have feedback

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -1386,7 +1386,7 @@ void Editor::runThread(){
     }else{
         is_running = true;
         allow_write = false;
-        model->runThread();
+        Program::instance()->program_entry_point->runThread();
     }
 }
 
@@ -1395,7 +1395,7 @@ bool Editor::isRunning() const noexcept{
 }
 
 void Editor::reenable() noexcept{
-    assert(model->interpreter.status == Code::Interpreter::FINISHED);
+    assert(Program::instance()->program_entry_point->interpreter.status == Code::Interpreter::FINISHED);
     is_running = false;
     allow_write = true;
 }

--- a/src/typeset_view.h
+++ b/src/typeset_view.h
@@ -269,6 +269,8 @@ protected:
     void setTooltipWarning(const std::string& str);
     void clearTooltip();
     friend Tooltip;
+    bool recommend_without_hint = false;
+    const Typeset::Marker* filename_start = nullptr;
 
 private slots:
     void rename();
@@ -285,6 +287,7 @@ signals:
 private:
     void rename(const std::string& str);
     virtual void recommend() override final;
+    void populateSuggestions();
     void takeRecommendation(const std::string& str);
 
     ParseNode contextNode = NONE;
@@ -293,6 +296,7 @@ private:
     static constexpr int TOOLTIP_DELAY_MILLISECONDS = 750;
 
     friend Recommender;
+    std::vector<std::string> suggestions;
 };
 
 }

--- a/src/typeset_view.h
+++ b/src/typeset_view.h
@@ -288,6 +288,9 @@ private:
     void rename(const std::string& str);
     virtual void recommend() override final;
     void populateSuggestions();
+    void suggestFileNames();
+    void suggestFileNames(const Typeset::Selection& sel);
+    void suggestModuleFields(const Typeset::Selection& sel);
     void takeRecommendation(const std::string& str);
 
     ParseNode contextNode = NONE;


### PR DESCRIPTION
This adds suggestions while typing import statements. The recommendation for module variables is very similar to later recommendation for class members.

The functionality works, but it should be cleaned up:
- [x] Make sure the std::filesystem usage is sensible
- [x] Make sure the branching recommendation population is clearly communicated