### PR TITLE
Validate UTF-8 at external boundaries

### DIFF
--- a/app/keywordsubstitutioneditor.cpp
+++ b/app/keywordsubstitutioneditor.cpp
@@ -65,7 +65,7 @@ void KeywordSubstitutionEditor::addSlot(){
 
 void KeywordSubstitutionEditor::remove(){
     KeywordSubstitutionLabel* label = getButtonLabel();
-    Keywords::map.erase(label->backup.toStdString());
+    Keywords::map.erase(toCppString(label->backup));
     form->removeRow(label);
 }
 
@@ -73,7 +73,7 @@ void KeywordSubstitutionEditor::updateKeyword(){
     KeywordSubstitutionLabel* label = focused_label;
     ModifiedLineEdit* edit = label->edit;
     const QString& new_keyword = edit->text();
-    std::string keyword = new_keyword.toStdString();
+    std::string keyword = toCppString(new_keyword);
 
     if(keyword.empty()){
         QMessageBox::warning(this, "Keyword rejected", "Keyword cannot be empty");
@@ -86,7 +86,7 @@ void KeywordSubstitutionEditor::updateKeyword(){
     }else{
         auto result = form->itemAt(form->indexOf(label) + 1);
         Keywords::map[keyword] = debug_cast<Forscape::Typeset::LineEdit*>(result->widget())->toSerial();
-        Keywords::map.erase(label->backup.toStdString());
+        Keywords::map.erase(toCppString(label->backup));
         label->backup = new_keyword;
     }
 }
@@ -96,7 +96,7 @@ void KeywordSubstitutionEditor::updateResult(){
     auto result_edit = debug_cast<Forscape::Typeset::LineEdit*>(sender);
     auto upcast_label = form->labelForField(sender);
     KeywordSubstitutionLabel* label = debug_cast<KeywordSubstitutionLabel*>(upcast_label);
-    Keywords::map[label->backup.toStdString()] = result_edit->toSerial();
+    Keywords::map[toCppString(label->backup)] = result_edit->toSerial();
 }
 
 void KeywordSubstitutionEditor::populateWidgetFromMap(){
@@ -161,7 +161,7 @@ KeywordSubstitutionEditor::KeywordSubstitutionLabel::KeywordSubstitutionLabel(
     edit = new ModifiedLineEdit(this);
     edit->setValidator(parent->validator);
     edit->setToolTip("Keyword");
-    backup = QString::fromStdString(label);
+    backup = toQString(label);
     edit->setText(backup);
     connect(edit, SIGNAL(editingFinished()), parent, SLOT(updateKeyword()));
     layout->addWidget(edit);

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -767,10 +767,17 @@ void MainWindow::openProject(QString path){
             src[i] = '\0';
     src.erase( std::remove(src.begin(), src.end(), '\0'), src.end() );
 
-    assert(Forscape::isValidSerial(src));
+    if(isIllFormedUtf8(src)){
+        QMessageBox messageBox;
+        messageBox.critical(nullptr, "Error", "\"" + path + "\" is not UTF-8 encoded.");
+        messageBox.setFixedSize(500,200);
+        return;
+    }
+
     if(!Forscape::isValidSerial(src)){
         QMessageBox messageBox;
-        messageBox.critical(nullptr, "Error", "\"" + path + "\" is corrupted.");
+        messageBox.critical(nullptr, "Error", "\"" + path + "\" does not conform to Forscape encoding.\n"
+            "This is caused by corruption, or erroneous typesetting specifiers.");
         messageBox.setFixedSize(500,200);
         return;
     }
@@ -1380,11 +1387,17 @@ void MainWindow::on_actionReload_triggered() {
             src[i] = '\0';
     src.erase( std::remove(src.begin(), src.end(), '\0'), src.end() );
 
-    assert(Forscape::isValidSerial(src));
+    if(isIllFormedUtf8(src)){
+        QMessageBox messageBox;
+        messageBox.critical(nullptr, "Error", "\"" + toQString(model->path) + "\" is not UTF-8 encoded.");
+        messageBox.setFixedSize(500,200);
+        return;
+    }
+
     if(!Forscape::isValidSerial(src)){
         QMessageBox messageBox;
-        QString str = toQString(model->path);
-        messageBox.critical(nullptr, "Error", "\"" + str + "\" is corrupted.");
+        messageBox.critical(nullptr, "Error", "\"" + toQString(model->path) + "\" does not conform to Forscape encoding.\n"
+            "This is caused by corruption, or erroneous typesetting specifiers.");
         messageBox.setFixedSize(500,200);
         return;
     }

--- a/app/searchdialog.h
+++ b/app/searchdialog.h
@@ -35,6 +35,7 @@ private slots:
     void on_findPrevButton_clicked();
     void on_replaceButton_clicked();
     void on_findEdit_textChanged(const QString& arg1);
+    void on_replaceEdit_textChanged(const QString&);
     void on_findAllButton_clicked();
     void on_caseBox_stateChanged(int);
     void on_wordBox_stateChanged(int);

--- a/src/forscape_serial.h
+++ b/src/forscape_serial.h
@@ -7,9 +7,15 @@
 #include <limits>
 #include <string>
 
+#ifndef NDEBUG
+#include "forscape_unicode.h"
+#endif
+
 namespace Forscape {
 
-inline bool isValidSerial(const std::string& src) noexcept{
+inline bool isValidSerial(const std::string& src) noexcept {
+    assert(!isIllFormedUtf8(src));
+
     uint32_t depth = 0;
     size_t index = 0;
     while(index < src.size()){

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -1111,6 +1111,7 @@ void View::handleKey(int key, int modifiers, const std::string& str){
         default:
             bool alt_or_ctrl_pressed = (Alt|Ctrl) & modifiers;
             if(!allow_write || alt_or_ctrl_pressed || str.empty()) return;
+            assert(isValidSerial(str)); //Shouldn't be able to enter invalid input via the keyboard
 
             if(insert_mode) controller.selectNextChar();
             std::string_view typeset_cmd = controller.keystroke(str);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,6 +95,7 @@ set(SOURCES
     ${TEST}/report.h
     ${TEST}/serial.h
     ${TEST}/test_keywords.h
+    ${TEST}/test_unicode.h
     ${TEST}/typeset.h
     ${TEST}/typeset_control.h
     ${TEST}/typeset_loadsave.h

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -4,6 +4,7 @@
 #include "code_scanner.h"
 #include "serial.h"
 #include "test_keywords.h"
+#include "test_unicode.h"
 #include "typeset_control.h"
 #include "typeset_loadsave.h"
 #include "typeset_mutability.h"
@@ -31,6 +32,7 @@ int main(int argc, char* argv[]){
     bool passing = true;
 
     printf("\n");
+    passing &= testUnicode();
     passing &= testSerial();
     passing &= testTypesetLoadSave();
     passing &= testTypesetController();

--- a/test/test_keywords.h
+++ b/test/test_keywords.h
@@ -1,5 +1,5 @@
-#ifndef TYPESET_KEYWORDS_H
-#define TYPESET_KEYWORDS_H
+#ifndef TEST_KEYWORDS_H
+#define TEST_KEYWORDS_H
 
 #include "report.h"
 #include <forscape_serial.h>
@@ -25,4 +25,4 @@ inline bool testKeywords(){
 }
 
 
-#endif // TYPESET_KEYWORDS_H
+#endif // TEST_KEYWORDS_H

--- a/test/test_unicode.h
+++ b/test/test_unicode.h
@@ -1,0 +1,46 @@
+#ifndef TEST_UNICODE_H
+#define TEST_UNICODE_H
+
+#include "report.h"
+#include <forscape_unicode.h>
+
+using namespace Forscape;
+
+inline bool testUnicode(){
+    bool passing = true;
+
+    #define CONTINUATION_CHAR "\x82"
+    #define TWO_BYTE_LEAD "\xC0"
+    #define THREE_BYTE_LEAD "\xEE"
+    #define FOUR_BYTE_LEAD "\xFF"
+    #define ZERO_WIDTH_CODEPOINT "\xCC\x88"
+
+    assert(!isIllFormedUtf8(""));
+    assert(!isIllFormedUtf8("Hello world!"));
+    assert(!isIllFormedUtf8("A = πr²"));
+    assert(!isIllFormedUtf8("mẍ + cẋ + kx = F"));
+    assert(!isIllFormedUtf8("\t\n\0"));
+    assert(!isIllFormedUtf8("x" ZERO_WIDTH_CODEPOINT));
+    assert(!isIllFormedUtf8(TWO_BYTE_LEAD CONTINUATION_CHAR));
+    assert(!isIllFormedUtf8(THREE_BYTE_LEAD CONTINUATION_CHAR CONTINUATION_CHAR));
+    assert(!isIllFormedUtf8(FOUR_BYTE_LEAD CONTINUATION_CHAR CONTINUATION_CHAR CONTINUATION_CHAR));
+    assert(!isIllFormedUtf8("(╯°□°)╯︵ ┻━┻"));
+    assert(!isIllFormedUtf8("( ͡° ͜ʖ ͡°)"));
+    assert(!isIllFormedUtf8("Unicode is cool 😎"));
+    assert(!isIllFormedUtf8("爱 кохання عشق Любовь אהבה 사랑 Αγάπη प्यार  Gràdh 愛する"));
+
+    assert(isIllFormedUtf8("Continuation char without leading byte:" CONTINUATION_CHAR));
+    assert(isIllFormedUtf8("Two continuation chars where one expected:" TWO_BYTE_LEAD CONTINUATION_CHAR CONTINUATION_CHAR));
+    assert(isIllFormedUtf8("No continuation char with end:" TWO_BYTE_LEAD));
+    assert(isIllFormedUtf8("No continuation char with text:" TWO_BYTE_LEAD "normal ASCII"));
+    assert(isIllFormedUtf8(THREE_BYTE_LEAD CONTINUATION_CHAR));
+    assert(isIllFormedUtf8(THREE_BYTE_LEAD CONTINUATION_CHAR CONTINUATION_CHAR CONTINUATION_CHAR));
+    assert(isIllFormedUtf8(FOUR_BYTE_LEAD CONTINUATION_CHAR CONTINUATION_CHAR "normal ASCII"));
+    assert(isIllFormedUtf8(ZERO_WIDTH_CODEPOINT "Leading zero-width codepoint"));
+
+    report("UTF-8 handling", passing);
+    return passing;
+}
+
+
+#endif // TEST_UNICODE_H


### PR DESCRIPTION
Reading a file or pasting from the clipboard will now display an error popup and return before having an impact if the content is not valid UTF-8.