### PR TITLE
Verify IDE stability

### DIFF
--- a/src/forscape_parser.cpp
+++ b/src/forscape_parser.cpp
@@ -800,11 +800,8 @@ ParseNode Parser::rightUnary(ParseNode n) alloc_except {
                 return pn;
             }
             case CARET:{
-                startPatch();
-                registerParseNodeRegionToPatch(index);
                 advance();
                 ParseNode pn = parse_tree.addNode<2>(OP_POWER, {n, implicitMult()});
-                finishPatch(pn);
                 return pn;
             }
             case TOKEN_SUPERSCRIPT: n = superscript(n); break;
@@ -1317,6 +1314,7 @@ ParseNode Parser::integer() alloc_except {
 
 ParseNode Parser::identifier() alloc_except{
     ParseNode id = terminalAndAdvance(OP_IDENTIFIER);
+    parse_tree.setSymbol(id, nullptr);
     registerParseNodeRegion(id, index-1);
     return identifierFollowOn(id);
 }
@@ -1390,6 +1388,7 @@ ParseNode Parser::identifierFollowOn(ParseNode id) noexcept{
 ParseNode Parser::isolatedIdentifier() alloc_except{
     if(!peek(IDENTIFIER)) return error(UNRECOGNIZED_SYMBOL);
     ParseNode id = terminalAndAdvance(OP_IDENTIFIER);
+    parse_tree.setSymbol(id, nullptr);
     registerParseNodeRegion(id, index-1);
     switch (currentType()) {
         case TOKEN_SUBSCRIPT:

--- a/src/forscape_symbol_lexical_pass.cpp
+++ b/src/forscape_symbol_lexical_pass.cpp
@@ -1013,6 +1013,7 @@ void SymbolLexicalPass::resolveScopeAccess(ParseNode pn) noexcept {
     //Create a usage for the RHS which will be patched later
     ParseNode rhs = parse_tree.arg<1>(pn);
     parse_tree.setFlag(rhs, symbol_usages.size());
+    parse_tree.setOp(rhs, OP_ERROR); //Proxy to prevent attempting to read this before it is validated
     symbol_usages.push_back(SymbolUsage(NONE, NONE, rhs, parse_tree.getSelection(rhs)));
 }
 

--- a/src/forscape_unicode.h
+++ b/src/forscape_unicode.h
@@ -234,7 +234,7 @@ inline bool isIllFormedUtf8(const std::string& str) noexcept {
         }
     }
 
-    return str.size() > 0 && isZeroWidth(codepointInt(str, 0));
+    return str.size() > 0 && isZeroWidth(codepointInt(str, 0)); //EVENTUALLY: should accommodate leading zero-width char?
 }
 
 }

--- a/src/typeset_controller.cpp
+++ b/src/typeset_controller.cpp
@@ -448,9 +448,7 @@ void Controller::detab() noexcept{
 }
 
 std::string_view Controller::keystroke(const std::string& str){
-    if(str.front() == syntax_cmd){
-        insertText(str);
-    }else if(hasSelection() || (active.index==0)){
+    if(hasSelection() || (active.index==0)){
         insertText(str);
     }else if(str.front() == ' '){
         insertText(str);

--- a/src/typeset_parser.cpp
+++ b/src/typeset_parser.cpp
@@ -239,8 +239,6 @@ const std::string& getSubstitution(const std::string& src) {
     return substitution;
 }
 
-
-
 }
 
 }

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -1699,8 +1699,11 @@ void Editor::showTooltipParseNode(){
             tooltip->appendSerial(parse_tree.str(hover_node) + " ∈ " + staticPass().typeString(*symbol));
 
             if(symbol->comment != NONE){
-                tooltip->appendSerial("\n");
-                tooltip->appendSerial(model->parser.parse_tree.str(symbol->comment), SEM_COMMENT);
+                std::string comment = model->parser.parse_tree.str(symbol->comment);
+                if(!isIllFormedUtf8(comment)){
+                    tooltip->appendSerial("\n");
+                    tooltip->appendSerial(model->parser.parse_tree.str(symbol->comment), SEM_COMMENT);
+                }
             }
 
             tooltip->fitToContents();

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -446,7 +446,9 @@ void View::resolveRightClick(double x, double y, int xScreen, int yScreen){
     menu.addSeparator();
     append("Select All", selectAll, true, true)
 
+    #ifndef TEST_QT
     menu.exec(QPoint(xScreen, yScreen));
+    #endif
 }
 
 void View::resolveWordClick(double x, double y){
@@ -1264,10 +1266,14 @@ void Label::appendSerial(const std::string& src, SemanticType type) {
 }
 
 void Label::fitToContents() noexcept {
+    //EVENTUALLY: this spams logs, and you need to fix the class hierarchy so that the label
+    // doesn't have scrollbars
+    #ifndef TEST_QT
     QWidget::resize(
         xScreen(model->getWidth()) + MARGIN_RIGHT,
         yScreen(model->getHeight()) + MARGIN_BOT
     );
+    #endif
 
     v_scroll->setVisible(false);
     h_scroll->setVisible(false);

--- a/src/typeset_view.h
+++ b/src/typeset_view.h
@@ -266,7 +266,7 @@ public:
     void clickLink(Forscape::Typeset::Model* model, size_t line);
 
     //EVENTUALLY: define hierarchy
-protected:
+protected: TEST_PUBLIC
     virtual void focusOutEvent(QFocusEvent* event) override;
     virtual void keyPressEvent(QKeyEvent* e) override final;
     virtual void leaveEvent(QEvent* event) override;

--- a/src/typeset_view.h
+++ b/src/typeset_view.h
@@ -6,6 +6,12 @@
 
 #include <QListWidget>
 
+#ifdef TEST_QT
+#define TEST_PUBLIC public:
+#else
+#define TEST_PUBLIC
+#endif
+
 class QScrollBar;
 
 namespace Forscape {
@@ -53,7 +59,7 @@ public:
 
     Typeset::Selection search_selection;
 
-protected:
+protected: TEST_PUBLIC
     void dispatchClick(double x, double y, int xScreen, int yScreen, bool right_click, bool shift_held) alloc_except;
     void dispatchRelease(double x, double y);
     void dispatchDoubleClick(double x, double y);
@@ -131,7 +137,6 @@ protected:
     void onBlink() noexcept;
 
 protected:
-    virtual std::string_view logPrefix() const noexcept = 0;
     void setCursorAppearance(double x, double y);
     void drawLinebox(double yT, double yB);
     void fillInScrollbarCorner();
@@ -160,7 +165,7 @@ public slots:
     void selectAll() noexcept;
     void changeIntegralPreference() noexcept;
 
-private:
+private:  TEST_PUBLIC
     void handleKey(int key, int modifiers, const std::string& str);
     void paste(const std::string& str);
 
@@ -183,8 +188,6 @@ public:
         controller.insertSerial(src);
     }
 
-    virtual std::string_view logPrefix() const noexcept override { return "console->"; }
-
 protected:
     void paintEvent(QPaintEvent* event) Q_DECL_OVERRIDE final;
 };
@@ -195,8 +198,6 @@ class LineEdit : public View {
     //EVENTUALLY: define hierarchy
 public:
     LineEdit();
-
-    virtual std::string_view logPrefix() const noexcept override { return "line_edit->"; }
 
 protected:
     void paintEvent(QPaintEvent* event) Q_DECL_OVERRIDE final;
@@ -214,7 +215,6 @@ public:
     void appendSerial(const std::string& src, SemanticType type);
     void fitToContents() noexcept;
     bool empty() const noexcept;
-    virtual std::string_view logPrefix() const noexcept override { return "label->"; }
 
 private:
     void paintEvent(QPaintEvent* event) Q_DECL_OVERRIDE final;
@@ -237,8 +237,6 @@ public:
     void moveDown() noexcept;
     void moveUp() noexcept;
     void take() noexcept;
-
-    virtual std::string_view logPrefix() const noexcept override { return "recommender->"; }
 
     Editor* editor = nullptr;
     size_t recommend_typeset_phrase_size = 0;
@@ -274,7 +272,6 @@ protected:
     virtual void leaveEvent(QEvent* event) override;
     virtual void mousePressEvent(QMouseEvent* e) override;
     virtual void wheelEvent(QWheelEvent* e) override;
-    virtual std::string_view logPrefix() const noexcept override { return "editor->"; }
     virtual void resolveTooltip(double x, double y) noexcept override;
     virtual void populateContextMenuFromModel(QMenu& menu, double x, double y) override;
     void setTooltipError(const std::string& str);
@@ -312,7 +309,11 @@ private:
     ParseNode contextNode = NONE;
     static Recommender* recommender;
     QTimer* tooltip_timer;
+    #ifdef TEST_QT
+    static constexpr int TOOLTIP_DELAY_MILLISECONDS = 0;
+    #else
     static constexpr int TOOLTIP_DELAY_MILLISECONDS = 750;
+    #endif
 
     friend Recommender;
     std::vector<std::string> suggestions;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SOURCES
     ${TEST}/forscape_benchmark.h
     ${TEST}/report.h
     ${TEST}/serial.h
+    ${TEST}/test_ide_interaction.h
     ${TEST}/test_keywords.h
     ${TEST}/test_unicode.h
     ${TEST}/typeset.h

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -12,6 +12,7 @@
 #include <typeset_themes.h>
 
 #ifdef TEST_QT
+#include "test_ide_interaction.h"
 #include <QApplication>
 #endif
 
@@ -42,6 +43,9 @@ int main(int argc, char* argv[]){
     passing &= testInterpreter();
     passing &= testIllFormedPrograms();
     passing &= testTypesetMutability();
+    #ifdef TEST_QT
+    passing &= testIdeInteraction();
+    #endif
 
     if(passing) printf("\nAll passing\n\n");
     else printf("\nTEST(S) FAILED\n\n");

--- a/test/test_ide_interaction.h
+++ b/test/test_ide_interaction.h
@@ -32,6 +32,7 @@ inline bool ideCase(const std::filesystem::path& path){
     input->postmutate();
 
     Typeset::Controller& controller = view->getController();
+    controller.moveToStartOfDocument();
     while(!controller.atEnd()){ view->handleKey(Qt::Key_Right, Qt::NoModifier, ""); QCoreApplication::processEvents(); }
     while(!controller.atStart()){ view->handleKey(Qt::Key_Left, Qt::NoModifier, ""); QCoreApplication::processEvents(); }
     while(!controller.atEnd()){ view->handleKey(Qt::Key_Right, Qt::ShiftModifier, ""); QCoreApplication::processEvents(); }

--- a/test/test_ide_interaction.h
+++ b/test/test_ide_interaction.h
@@ -1,0 +1,66 @@
+#include <forscape_interpreter.h>
+#include <forscape_parser.h>
+#include <forscape_program.h>
+#include <forscape_scanner.h>
+#include "report.h"
+#include "typeset.h"
+#include <typeset_view.h>
+#include <QCoreApplication>
+
+#if !defined(__MINGW32__) || (__MINGW64_VERSION_MAJOR > 8)
+#include <filesystem>
+using std::filesystem::directory_iterator;
+#else
+#error std::filesystem is borked for MinGW versions before 9.0
+#endif
+
+using namespace Forscape;
+using namespace Code;
+
+inline bool ideCase(const std::filesystem::path& path){
+    std::string in = readFile(path.u8string());
+
+    Typeset::Editor* view = new Typeset::Editor;
+    Typeset::Model* input = Typeset::Model::fromSerial(in);
+    view->setModel(input);
+    input->path = std::filesystem::canonical(path);
+    Forscape::Program::instance()->setProgramEntryPoint(input->path, input);
+    input->postmutate();
+
+    Typeset::Controller& controller = view->getController();
+    while(!controller.atEnd()){ view->handleKey(Qt::Key_Right, Qt::NoModifier, ""); QCoreApplication::processEvents(); }
+    while(!controller.atStart()){ view->handleKey(Qt::Key_Left, Qt::NoModifier, ""); QCoreApplication::processEvents(); }
+    while(!controller.atEnd()){ view->handleKey(Qt::Key_Right, Qt::ShiftModifier, ""); QCoreApplication::processEvents(); }
+    controller.deselect();
+    while(!controller.atStart()){ view->handleKey(Qt::Key_Left, Qt::ShiftModifier, ""); QCoreApplication::processEvents(); }
+    controller.deselect();
+
+    //DO THIS: test hover
+    /*
+    do {
+        const Typeset::Marker& anchor = controller.getAnchor();
+        view->dispatchHover(anchor.x()+1, anchor.y()+1);
+        for(size_t i = 0; i < 10; i++) QCoreApplication::processEvents();
+        view->handleKey(Qt::Key_Right, Qt::NoModifier, "");
+    } while(!controller.atEnd());
+    */
+
+    delete view;
+    Program::instance()->freeFileMemory();
+
+    return true;
+}
+
+inline bool testIdeInteraction(){
+    bool passing = true;
+
+    for(directory_iterator end, dir(BASE_TEST_DIR "/in"); dir != end; dir++)
+        passing &= ideCase(dir->path());
+
+    //DO THIS: test error cases
+    //for(directory_iterator end, dir(BASE_TEST_DIR "/errors"); dir != end; dir++)
+    //    passing &= ideCase(dir->path());
+
+    report("IDE interaction", passing);
+    return passing;
+}


### PR DESCRIPTION
For all files in the test suite, including Forscape programs with errors meant to test stability:

- Move the cursor from left to right, then right to left, which will trigger variable highlighting
- Select the cursor from left to right, deselect, right to left, deselect
- Move the cursor from left to right, resolving the tool tip at the cursor location, and filling the context menu

This also fixes several crashes discovered in the process of testing