### PR TITLE
Fix phrase paint cutoff and prevent linux zoom bug

### DIFF
--- a/src/typeset_phrase.cpp
+++ b/src/typeset_phrase.cpp
@@ -372,13 +372,14 @@ void Phrase::paint(Painter& painter, double xL, double xR) const {
     Text* tL = textLeftOf(xL);
     Text* tR = textRightOf(xR);
 
+    Typeset::Marker r_mark(tR, tR->charIndexLeft(xR));
+    if(!r_mark.atTextEnd()) r_mark.incrementGrapheme();
+
     if(tL == tR){
-        Typeset::Marker r_mark(tR, tR->charIndexLeft(xR));
-        if(!r_mark.atTextEnd()) r_mark.incrementGrapheme();
         painter.setScriptLevel(script_level);
         tL->paintMid(painter, tL->charIndexLeft(xL), r_mark.index);
     }else{
-        paintMid(painter, tL, tL->charIndexLeft(xL), tR, 0);
+        paintMid(painter, tL, tL->charIndexLeft(xL), tR, r_mark.index);
     }
 }
 

--- a/src/typeset_view.h
+++ b/src/typeset_view.h
@@ -89,8 +89,13 @@ protected: TEST_PUBLIC
     double getLineboxWidth() const noexcept;
 
     static constexpr double ZOOM_DEFAULT = 1.2;
+    #ifdef linux
+    //EVENTUALLY: QPainter::drawText suffers terrible performance at high zoom on linux
+    static constexpr double ZOOM_MAX = 2.0*ZOOM_DEFAULT; static_assert(ZOOM_DEFAULT <= ZOOM_MAX);
+    #else
     static constexpr double ZOOM_MAX = 2.5*ZOOM_DEFAULT; static_assert(ZOOM_DEFAULT <= ZOOM_MAX);
-    static constexpr double ZOOM_MIN = 0.375/2*ZOOM_DEFAULT; static_assert(ZOOM_DEFAULT >= ZOOM_MIN);
+    #endif
+    static constexpr double ZOOM_MIN = 0.375/ZOOM_DEFAULT; static_assert(ZOOM_DEFAULT >= ZOOM_MIN);
     static constexpr double ZOOM_DELTA = 1.1; static_assert(ZOOM_DELTA > 1);
     static constexpr size_t CURSOR_BLINK_INTERVAL = 600;
     static constexpr bool ALLOW_SELECTION_DRAG = true;


### PR DESCRIPTION
The last text in a phrase was not painting to the end of the screen. On Linux, QPainter::drawText has terrible bottlenecking performance at high zoom. Workaround by limiting max zoom for now.