### PR TITLE
Project Management

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -118,6 +118,8 @@ set(PROJECT_SOURCES
     preferences.cpp
     preferences.h
     preferences.ui
+    projectbrowser.cpp
+    projectbrowser.h
     qgraphvizcall.h
     searchdialog.cpp
     searchdialog.h

--- a/app/conanfile.txt
+++ b/app/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 eigen/3.4.0
-# gmp/6.2.1
-parallel-hashmap/1.35
+# gmp/6.3.0
+parallel-hashmap/1.37
 readerwriterqueue/1.0.6
 
 [generators]

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -54,6 +54,7 @@
 #endif
 
 #ifdef FORSCAPE_WORKAROUND_QT_LINUX_FILETYPE_FILTER_BUG
+#include <QFileIconProvider>
 #include <QFileSystemModel>
 #include <QSortFilterProxyModel>
 #define FORSCAPE_FILE_TYPE_DESC "Forscape script (*)"

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -491,10 +491,10 @@ void MainWindow::on_actionNew_Project_triggered() {
     active_file_path.clear();
     project_path.clear();
 
-    project_browser->populateWithNewProject(model);
     Forscape::Program::instance()->setProgramEntryPoint("", model);
     model->performSemanticFormatting();
     editor->setModel(model);
+    project_browser->populateWithNewProject(model);
 
     if(recent_projects.empty()) recent_projects.push_back(project_path);
 

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1242,6 +1242,7 @@ void MainWindow::viewModel(Forscape::Typeset::Model* model, size_t line) {
     viewing_index = viewing_chain.size()-1;
     setEditorToModelAndLine(model, line);
     updateViewJumpPointElements();
+    project_browser->setCurrentlyViewed(model);
 }
 
 void MainWindow::viewModel(Forscape::Typeset::Model* model) {

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -84,8 +84,6 @@ static constexpr int CHANGE_CHECK_PERIOD_MS = 500;
 static constexpr int FILE_BROWSER_WIDTH = 200;
 static bool program_control_of_hsplitter = false;
 
-//DO THIS: the CTRL+N action is counter intuitive
-
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow){
@@ -300,6 +298,14 @@ MainWindow::MainWindow(QWidget* parent)
         on_actionNew_triggered();
     }
     resetViewJumpPointElements();
+
+    QAction* new_keyboard_shortcut = new QAction(tr("Create new..."), this);
+    new_keyboard_shortcut->setShortcut(QKeySequence::New);
+    connect(new_keyboard_shortcut, SIGNAL(triggered()), this, SLOT(onKeyboardNew()));
+    addAction(new_keyboard_shortcut);
+
+    // By default there are options to hide the toolbars, but they don't play nicely with custom show/hide options
+    setContextMenuPolicy(Qt::NoContextMenu);
 }
 
 MainWindow::~MainWindow(){
@@ -424,7 +430,7 @@ void MainWindow::pollInterpreterThread(){
     }
 }
 
-void MainWindow::parseTree(){
+void MainWindow::parseTree() {
     #ifndef NDEBUG
     QString dot_src = toQString(editor->getModel()->parseTreeDot());
     dot_src.replace("\\n", "\\\\n");
@@ -432,7 +438,7 @@ void MainWindow::parseTree(){
     #endif
 }
 
-void MainWindow::symbolTable(){
+void MainWindow::symbolTable() {
     #ifndef NDEBUG
     Typeset::Model* m = editor->getModel();
     SymbolTreeView* view = new SymbolTreeView(m->symbol_builder.symbol_table, Forscape::Program::instance()->static_pass);
@@ -440,8 +446,30 @@ void MainWindow::symbolTable(){
     #endif
 }
 
-void MainWindow::github(){
+void MainWindow::github() {
     QDesktopServices::openUrl(QUrl("https://github.com/JohnDTill/Forscape"));
+}
+
+void MainWindow::onKeyboardNew() {
+    const QStringList options {
+        "Project",
+        "File",
+    };
+
+    //DO THIS: I don't like the appearance of this dialog, and the string comparison hurts me
+
+    bool success;
+    QString item = QInputDialog::getItem(this, tr("Creation Dialog"),
+                                         tr("Create new:"), options, 0, false, &success);
+    if(!success) return;
+
+    if(item == "Project"){
+        on_actionNew_Project_triggered();
+    }else if(item == "File"){
+        on_actionNew_triggered();
+    }else{
+        assert(false);
+    }
 }
 
 void MainWindow::on_actionNew_Project_triggered() {

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -17,6 +17,7 @@
 #include <QBuffer>
 #include <QClipboard>
 #include <QCloseEvent>
+#include <QComboBox>
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QGroupBox>
@@ -451,24 +452,20 @@ void MainWindow::github() {
 }
 
 void MainWindow::onKeyboardNew() {
-    const QStringList options {
+    QInputDialog dialog(this);
+    dialog.setWindowFlags(dialog.windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    dialog.setWindowTitle("Creation Prompt");
+    dialog.setLabelText(tr("Create new..."));
+    dialog.setComboBoxItems({
         "Project",
         "File",
-    };
+    });
 
-    //DO THIS: I don't like the appearance of this dialog, and the string comparison hurts me
-
-    bool success;
-    QString item = QInputDialog::getItem(this, tr("Creation Dialog"),
-                                         tr("Create new:"), options, 0, false, &success);
-    if(!success) return;
-
-    if(item == "Project"){
-        on_actionNew_Project_triggered();
-    }else if(item == "File"){
-        on_actionNew_triggered();
-    }else{
-        assert(false);
+    if(dialog.exec() != QDialog::Accepted) return;
+    switch( dialog.findChild<QComboBox*>()->currentIndex() ){
+        case 0: on_actionNew_Project_triggered(); break;
+        case 1: on_actionNew_triggered(); break;
+        default: assert(false);
     }
 }
 

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -18,8 +18,6 @@ class ProjectBrowser;
 class SearchDialog;
 class QGroupBox;
 class QSplitter;
-class QTreeWidget;
-class QTreeWidgetItem;
 class Splitter;
 
 namespace Forscape{
@@ -40,6 +38,12 @@ public:
     QSettings settings;
     Forscape::Typeset::Editor* editor;
 
+public slots:
+    void viewModel(Forscape::Typeset::Model* model, size_t line);
+    void viewModel(Forscape::Typeset::Model* model);
+    void on_actionNew_triggered();
+    void hideProjectBrowser() noexcept;
+
 private:
     SearchDialog* search;
     Ui::MainWindow* ui;
@@ -49,7 +53,6 @@ private:
     QToolBar* action_toolbar;
     QToolBar* project_toolbar;
     ProjectBrowser* project_browser;
-    QTreeWidgetItem* project_browser_active_item;
     Splitter* horizontal_splitter;
     Splitter* vertical_splitter;
     Preferences* preferences;
@@ -86,7 +89,6 @@ private slots:
     void symbolTable();
     void github();
     void on_actionNew_Project_triggered();
-    void on_actionNew_triggered();
     void on_actionOpen_triggered();
     bool on_actionSave_triggered();
     void on_actionSave_As_triggered();
@@ -123,16 +125,10 @@ private slots:
     void onColourChanged();
     void on_actionGo_to_line_triggered();
     void onSplitterResize(int pos, int index);
-    void onFileClicked(QTreeWidgetItem* item, int column);
-    void onFileClicked();
-    void onShowInExplorer();
-    void onDeleteFile();
-    void onFileRightClicked(const QPoint& pos);
     void setHSplitterDefaultWidth();
     void setVSplitterDefaultHeight();
     void on_actionGoBack_triggered();
     void on_actionGoForward_triggered();
-    void viewModel(Forscape::Typeset::Model* model, size_t line);
     void viewSelection(const Forscape::Typeset::Selection& sel);
     bool on_actionSave_All_triggered();
     void on_actionReload_triggered();
@@ -155,15 +151,10 @@ private:
     void addSeries(const std::vector<std::pair<double, double>>& data) const alloc_except;
     QString getLastDir();
     void setEditorToModelAndLine(Forscape::Typeset::Model* model, size_t line);
-    void updateProjectBrowser();
-    void addProjectEntry(Forscape::Typeset::Model* model);
     void loadRecentProjects();
     void updateRecentProjectsFromList();
     void updateRecentProjectsFromCurrent();
-    void linkFileToAncestor(QTreeWidgetItem* file_item, const std::filesystem::path file_path);
-    void linkItemToExistingAncestor(QTreeWidgetItem* item, std::filesystem::path path);
 
-    FORSCAPE_UNORDERED_MAP<std::filesystem::path, QTreeWidgetItem*> project_browser_entries;
     FORSCAPE_UNORDERED_SET<Forscape::Typeset::Model*> modified_files;
     QStringList recent_projects;
     static constexpr int MAX_DISPLAYED_RECENT_PROJECTS = 20;

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -14,13 +14,14 @@ QT_END_NAMESPACE
 class MathToolbar;
 class Plot;
 class Preferences;
-class ProjectBrowser;
 class SearchDialog;
 class QGroupBox;
 class QSplitter;
 class Splitter;
 
 namespace Forscape{
+class ProjectBrowser;
+
 namespace Typeset {
 class Console;
 class Editor;
@@ -52,7 +53,7 @@ private:
     MathToolbar* math_toolbar;
     QToolBar* action_toolbar;
     QToolBar* project_toolbar;
-    ProjectBrowser* project_browser;
+    Forscape::ProjectBrowser* project_browser;
     Splitter* horizontal_splitter;
     Splitter* vertical_splitter;
     Preferences* preferences;

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -36,6 +36,7 @@ public:
     MainWindow(QWidget* parent = nullptr);
     virtual ~MainWindow();
     void openProject(QString path);
+    void removeFile(Forscape::Typeset::Model* model) noexcept;
     QSettings settings;
     Forscape::Typeset::Editor* editor;
 
@@ -44,6 +45,7 @@ public slots:
     void viewModel(Forscape::Typeset::Model* model);
     void on_actionNew_triggered();
     void hideProjectBrowser() noexcept;
+    void reparse();
 
 private:
     SearchDialog* search;
@@ -78,6 +80,10 @@ private:
         JumpPoint() noexcept = default;
         JumpPoint(Forscape::Typeset::Model* model, size_t line) noexcept :
             model(model), line(line){}
+
+        bool operator==(const JumpPoint& other) const noexcept {
+            return model == other.model && line == other.line;
+        }
     };
     std::vector<JumpPoint> viewing_chain;
     size_t viewing_index = 0;

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -14,6 +14,7 @@ QT_END_NAMESPACE
 class MathToolbar;
 class Plot;
 class Preferences;
+class ProjectBrowser;
 class SearchDialog;
 class QGroupBox;
 class QSplitter;
@@ -47,7 +48,7 @@ private:
     MathToolbar* math_toolbar;
     QToolBar* action_toolbar;
     QToolBar* project_toolbar;
-    QTreeWidget* project_browser;
+    ProjectBrowser* project_browser;
     QTreeWidgetItem* project_browser_active_item;
     Splitter* horizontal_splitter;
     Splitter* vertical_splitter;
@@ -125,6 +126,7 @@ private slots:
     void onFileClicked(QTreeWidgetItem* item, int column);
     void onFileClicked();
     void onShowInExplorer();
+    void onDeleteFile();
     void onFileRightClicked(const QPoint& pos);
     void setHSplitterDefaultWidth();
     void setVSplitterDefaultHeight();

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -54,7 +54,6 @@ private:
     QGroupBox* group_box;
     MathToolbar* math_toolbar;
     QToolBar* action_toolbar;
-    QToolBar* project_toolbar;
     Forscape::ProjectBrowser* project_browser;
     Splitter* horizontal_splitter;
     Splitter* vertical_splitter;
@@ -95,6 +94,7 @@ private slots:
     void parseTree();
     void symbolTable();
     void github();
+    void onKeyboardNew();
     void on_actionNew_Project_triggered();
     void on_actionOpen_triggered();
     bool on_actionSave_triggered();

--- a/app/mainwindow.ui
+++ b/app/mainwindow.ui
@@ -111,7 +111,7 @@
     <string>New File</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+N</string>
+    <string>Alt+N</string>
    </property>
   </action>
   <action name="actionOpen">

--- a/app/mathtoolbar.cpp
+++ b/app/mathtoolbar.cpp
@@ -14,6 +14,8 @@ using namespace Typeset;
 static QFont glyph_font;
 
 MathToolbar::MathToolbar(QWidget* parent) : QToolBar(parent) {
+    setWindowTitle(tr("Typesetting toolbar"));
+
     int id = QFontDatabase::addApplicationFont(":/fonts/toolbar_glyphs.otf");
     assert(id!=-1);
     QString family = QFontDatabase::applicationFontFamilies(id).at(0);

--- a/app/projectbrowser.cpp
+++ b/app/projectbrowser.cpp
@@ -1,9 +1,362 @@
 #include "projectbrowser.h"
 
-ProjectBrowser::ProjectBrowser(QWidget* parent)
-    : QTreeWidget(parent) {
+#include "mainwindow.h"
+
+#include <forscape_program.h>
+#include <typeset_model.h>
+#include <qt_compatability.h>
+
+#include <QAction>
+#include <QDir>
+#include <QFileIconProvider>
+#include <QMenu>
+#include <QProcess>
+
+//DO THIS: the project view is unintuitive. Allow multiple open projects?
+//DO THIS: need assurance that the viewing history remains valid as files are deleted, renamed, w/e
+//DO THIS: the project browser should probably have an undo stack
+
+Q_DECLARE_METATYPE(Forscape::Typeset::Model*); //EVENTUALLY: this is only for compability with old versions
+
+static QIcon main_icon;
+static QIcon file_icon;
+static QIcon folder_icon;
+
+static Forscape::Typeset::Model* getModelForEntry(const QTreeWidgetItem* item) noexcept {
+    assert(item->childCount() == 0);
+    return item->data(0, Qt::UserRole).value<Forscape::Typeset::Model*>();
+}
+
+static bool itemIsFile(const QTreeWidgetItem* item) noexcept {
+    return item->childCount() == 0;
+}
+
+static bool isSavedToDisk(const QTreeWidgetItem* item) noexcept {
+    return !getModelForEntry(item)->path.empty();
+}
+
+ProjectBrowser::ProjectBrowser(QWidget* parent, MainWindow* main_window)
+    : QTreeWidget(parent), main_window(main_window) {
     setHeaderHidden(true);
     setIndentation(10);
     setMinimumWidth(120);
-    setRootIsDecorated(false);
+    setRootIsDecorated(false); //Hide a universal root entry, so the user has the illusion of multiple "top-level" entries
+    setContextMenuPolicy(Qt::CustomContextMenu); //Needed to enable context menu
+
+    main_icon = QIcon(":/fonts/anchor.svg");
+    file_icon = QIcon(":/fonts/pi_file.svg");
+    folder_icon = QFileIconProvider().icon(QFileIconProvider::Folder);
+
+    connect(this, SIGNAL(itemActivated(QTreeWidgetItem*, int)), this, SLOT(onFileClicked(QTreeWidgetItem*, int)));
+    connect(this, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(onRightClick(const QPoint&)));
+}
+
+void ProjectBrowser::setProject(Forscape::Typeset::Model* model) {
+    clear();
+    const std::filesystem::path& std_path = model->path;
+    QTreeWidgetItem* root = invisibleRootItem();
+    QTreeWidgetItem* main_file = new QTreeWidgetItem(root);
+    main_file->setText(0, toQString(std_path.filename()));
+    main_file->setIcon(0, main_icon);
+    main_file->setData(0, Qt::UserRole, QVariant::fromValue(model));
+    model->project_browser_entry = main_file;
+    project_browser_entries[std_path] = main_file;
+    const std::filesystem::path parent_path = std_path.parent_path();
+    project_browser_entries[parent_path] = root;
+    root->setData(0, Qt::UserRole, toQString(parent_path));
+    currently_viewed_item = main_file;
+    QFont normal_font = font();
+    QFont bold_font = normal_font;
+    bold_font.setBold(true);
+    currently_viewed_item->setFont(0, bold_font);
+}
+
+void ProjectBrowser::addFile(Forscape::Typeset::Model* model) {
+    QTreeWidgetItem* item = new QTreeWidgetItem(this);
+    item->setText(0, "untitled");
+    item->setIcon(0, file_icon);
+    item->setData(0, Qt::UserRole, QVariant::fromValue(model));
+    sortItems(0, Qt::SortOrder::AscendingOrder);
+    model->project_browser_entry = item;
+}
+
+void ProjectBrowser::saveModel(Forscape::Typeset::Model* saved_model, const std::filesystem::path& std_path) {
+    std::filesystem::path old_path = saved_model->path;
+    const bool create_new_file = old_path.empty();
+    const bool rename_file = saved_model->path != std_path && !create_new_file;
+
+    if(rename_file){
+        //EVENTUALLY: this is a hacky solution to keep the old file, which is likely referenced in code
+        Forscape::Program::instance()->source_files.erase(old_path);
+        project_browser_entries.erase(old_path);
+        Forscape::Program::instance()->openFromAbsolutePath(old_path);
+    }
+
+    if(create_new_file || rename_file){
+        saved_model->path = std_path;
+        QTreeWidgetItem* item = saved_model->project_browser_entry;
+        item->setText(0, toQString(std_path.filename()));
+        auto result = project_browser_entries.insert({std_path, item});
+        if(!result.second){
+            //Saving over existing project file
+            QTreeWidgetItem* overwritten = result.first->second;
+            Forscape::Typeset::Model* overwritten_model = getModelForEntry(overwritten);
+            delete overwritten_model;
+            /* DO THIS
+            modified_files.erase(overwritten_model);
+            for(auto& entry : viewing_chain)
+                if(entry.model == overwritten_model)
+                    entry.model = saved_model;
+            */
+            removeItemWidget(overwritten, 0);
+            delete overwritten;
+            result.first->second = item;
+        }else{
+            //New file created
+            invisibleRootItem()->removeChild(item);
+            linkFileToAncestor(item, std_path);
+        }
+    }
+    sortItems(0, Qt::SortOrder::AscendingOrder);
+}
+
+void ProjectBrowser::updateProjectBrowser() {
+    const auto& parsed_files = Forscape::Program::instance()->getPendingProjectBrowserUpdates();
+    if(parsed_files.empty()) return;
+
+    for(const auto& entry : parsed_files) addProjectEntry(entry);
+    Forscape::Program::instance()->clearPendingProjectBrowserUpdates();
+    sortByColumn(0, Qt::AscendingOrder);
+}
+
+void ProjectBrowser::addProjectEntry(Forscape::Typeset::Model* model) {
+    std::filesystem::path path = model->path;
+    assert(project_browser_entries.find(path) == project_browser_entries.end());
+
+    QTreeWidgetItem* tree_item = new QTreeWidgetItem;
+    model->project_browser_entry = tree_item;
+    tree_item->setData(0, Qt::UserRole, QVariant::fromValue(model));
+    tree_item->setText(0, toQString(path.filename()));
+    tree_item->setIcon(0, file_icon);
+    project_browser_entries[path] = tree_item;
+
+    model->write_time = std::filesystem::file_time_type::clock::now();
+
+    linkFileToAncestor(tree_item, path);
+}
+
+void ProjectBrowser::populateWithNewProject(Forscape::Typeset::Model* model) {
+    clear();
+    QTreeWidgetItem* item = new QTreeWidgetItem(this);
+    item->setText(0, "untitled");
+    item->setIcon(0, main_icon);
+    item->setData(0, Qt::UserRole, QVariant::fromValue(model));
+    sortItems(0, Qt::SortOrder::AscendingOrder);
+    model->project_browser_entry = item;
+    currently_viewed_item = item;
+    item->setSelected(true);
+    QFont f = font();
+    f.setBold(true);
+    item->setFont(0, f);
+}
+
+void ProjectBrowser::setCurrentlyViewed(Forscape::Typeset::Model* model) {
+    QFont normal_font = font();
+    QFont bold_font = normal_font;
+    bold_font.setBold(true);
+
+    //Remove highlighting on the old item
+    currently_viewed_item->setFont(0, QFont());
+
+    //Highlight the new item
+    currently_viewed_item = model->project_browser_entry;
+    currently_viewed_item->setFont(0, bold_font);
+    setCurrentItem(currently_viewed_item);
+}
+
+void ProjectBrowser::clear() noexcept {
+    QTreeWidget::clear();
+    project_browser_entries.clear();
+}
+
+void ProjectBrowser::onFileClicked(QTreeWidgetItem* item, int column) {
+    if(itemIsFile(item)) main_window->viewModel(getModelForEntry(item));
+}
+
+void ProjectBrowser::onFileClicked() {
+    onFileClicked(currentItem(), 0);
+}
+
+void ProjectBrowser::onShowInExplorer() {
+    const QTreeWidgetItem* item = currentItem();
+
+    QStringList args;
+
+    if(item->childCount() == 0){
+        assert(isSavedToDisk(item));
+        auto m = getModelForEntry(item);
+        args << "/select," << QDir::toNativeSeparators(toQString(m->path));
+    }else{
+        QString q_path = item->data(0, Qt::UserRole).toString();
+        args << QDir::toNativeSeparators(q_path);
+    }
+
+    QProcess* process = new QProcess(this);
+    process->start("explorer.exe", args);
+}
+
+void ProjectBrowser::onDeleteFile() {
+    QTreeWidgetItem* item = currentItem();
+    auto m = getModelForEntry(item);
+    assert(itemIsFile(item));
+    if(!m->notOnDisk()) std::filesystem::remove(m->path);
+
+    assert(m != Forscape::Program::instance()->program_entry_point);
+    delete m;
+    delete item;
+
+    //DO THIS: this has implications for the viewing buffer
+
+    //editor->updateModel(); //DO THIS: update the model now that imports may be broken
+}
+
+void ProjectBrowser::onRightClick(const QPoint& pos) {
+    QMenu menu(this);
+    menu.setToolTipsVisible(true);
+
+    QTreeWidgetItem* item = itemAt(pos);
+    if(item == nullptr){
+        QAction* new_file = menu.addAction(tr("Add New File"));
+        new_file->setToolTip(tr("Create a new file for the project"));
+        connect(new_file, SIGNAL(triggered(bool)), main_window, SLOT(on_actionNew_triggered()));
+
+        QAction* hide = menu.addAction(tr("Hide project browser"));
+        hide->setToolTip(tr("Remove the project browser from view"));
+        connect(hide, SIGNAL(triggered(bool)), main_window, SLOT(hideProjectBrowser()));
+    }else if(item->childCount() == 0){
+        //Item is file
+        QAction* open_file = menu.addAction(tr("Open File"));
+        open_file->setToolTip(tr("Open the selected file in the editor"));
+        connect(open_file, SIGNAL(triggered(bool)), this, SLOT(onFileClicked()));
+
+        if(isSavedToDisk(item)){
+            QAction* show_in_explorer = menu.addAction(tr("Show in Explorer"));
+            show_in_explorer->setToolTip(tr("Show in the OS file browser"));
+            connect(show_in_explorer, SIGNAL(triggered(bool)), this, SLOT(onShowInExplorer()));
+        }
+
+        auto m = getModelForEntry(item);
+        if(m != Forscape::Program::instance()->program_entry_point){
+            QAction* delete_file = menu.addAction(tr("Delete"));
+            delete_file->setToolTip(tr("Erase this file"));
+            connect(delete_file, SIGNAL(triggered(bool)), this, SLOT(onDeleteFile()));
+        }
+
+        QAction* rename_file = menu.addAction(tr("Rename"));
+        rename_file->setToolTip("Change the filename");
+        //DO THIS
+    }else{
+        QAction* show_in_explorer = menu.addAction(tr("Show in Explorer"));
+        show_in_explorer->setToolTip(tr("Show in the OS file browser"));
+        connect(show_in_explorer, SIGNAL(triggered(bool)), this, SLOT(onShowInExplorer()));
+
+        QAction* rename_folder = menu.addAction(tr("Rename"));
+        rename_folder->setToolTip("Change the directory name");
+        //DO THIS
+    }
+
+    menu.exec(mapToGlobal(pos));
+}
+
+void ProjectBrowser::linkFileToAncestor(QTreeWidgetItem* file_item, const std::filesystem::path file_path) {
+    assert(std::filesystem::is_regular_file(file_path));
+
+    QTreeWidgetItem* root = invisibleRootItem();
+    QString stale_root_path_str = root->data(0, Qt::UserRole).toString();
+    std::filesystem::path stale_root_path = toCppPath(stale_root_path_str);
+    std::filesystem::path folder_path = file_path.parent_path();
+
+    //Link the file to it's folder
+    auto result = project_browser_entries.find(folder_path);
+    if(result != project_browser_entries.end()){
+        //Folder already exists
+        QTreeWidgetItem* preexisting_folder_entry = result->second;
+        preexisting_folder_entry->addChild(file_item);
+        return;
+    }
+
+    QList<QTreeWidgetItem*> taken_children;
+
+    //Find common ancestor of root directory and folder
+    if(stale_root_path_str.isEmpty()){
+        //Browser already showing different drives, do nothing
+    }else if(stale_root_path.root_name() != file_path.root_name()){
+        //These files come from different drives; change root to nothing since no common ancestor
+        project_browser_entries.erase(stale_root_path);
+        root->setData(0, Qt::UserRole, QString());
+        taken_children = root->takeChildren();
+    }else{
+        //Check if the root needs to change
+        auto root_path_str = stale_root_path.u8string();
+        auto folder_path_str = folder_path.u8string();
+        const size_t root_path_size = root_path_str.size();
+
+        size_t uncommon_index = std::min(root_path_size, folder_path_str.size());
+        for(size_t i = 0; i < uncommon_index; i++)
+            if(root_path_str[i] != folder_path_str[i]){
+                uncommon_index = i;
+                break;
+            }
+
+        //Root needs to move up
+        if(uncommon_index < root_path_size){
+            std::filesystem::path new_root_path = stale_root_path.parent_path();
+            while(new_root_path.u8string().size() > uncommon_index){
+                assert(new_root_path.has_parent_path());
+                new_root_path = new_root_path.parent_path();
+            }
+
+            taken_children = root->takeChildren();
+            project_browser_entries.erase(stale_root_path);
+            project_browser_entries[new_root_path] = root;
+            root->setData(0, Qt::UserRole, toQString(new_root_path));
+        }
+    }
+
+    linkItemToExistingAncestor(file_item, file_path);
+
+    if(!taken_children.empty()){
+        linkItemToExistingAncestor(taken_children.back(), stale_root_path / "fake");
+        taken_children.pop_back();
+        QTreeWidgetItem* entry_for_stale_root = project_browser_entries[stale_root_path];
+        entry_for_stale_root->addChildren(taken_children);
+        setCurrentItem(currently_viewed_item);
+    }
+}
+
+void ProjectBrowser::linkItemToExistingAncestor(QTreeWidgetItem* item, std::filesystem::path path) {
+    path = path.parent_path();
+    auto parent_result = project_browser_entries.insert({path, nullptr});
+    while(parent_result.second){
+        QTreeWidgetItem* new_item = new QTreeWidgetItem;
+        new_item->addChild(item);
+        item = new_item;
+        item->setText(0, toQString(path.filename()));
+        item->setData(0, Qt::UserRole, toQString(path));
+        item->setIcon(0, folder_icon);
+        item->setExpanded(true);
+        parent_result.first->second = item;
+
+        auto parent_path = path.parent_path();
+        if(parent_path != path){ //has_parent_path() lies, causing an infinite loop
+            path = parent_path;
+            parent_result = project_browser_entries.insert({path, nullptr});
+        }else{
+            invisibleRootItem()->addChild(item);
+            item->setText(0, toQString(*path.begin()));
+            return;
+        }
+    }
+
+    parent_result.first->second->addChild(item);
 }

--- a/app/projectbrowser.cpp
+++ b/app/projectbrowser.cpp
@@ -1,0 +1,9 @@
+#include "projectbrowser.h"
+
+ProjectBrowser::ProjectBrowser(QWidget* parent)
+    : QTreeWidget(parent) {
+    setHeaderHidden(true);
+    setIndentation(10);
+    setMinimumWidth(120);
+    setRootIsDecorated(false);
+}

--- a/app/projectbrowser.cpp
+++ b/app/projectbrowser.cpp
@@ -365,6 +365,8 @@ void ProjectBrowser::onFileRenamed() {
     FileEntry& entry = getSelectedFileEntry();
     const QString old_name = currentItem()->text(0);
 
+    //DO THIS: get rid of context menu hint
+
     bool ok;
     QString text = QInputDialog::getText(
                 this,

--- a/app/projectbrowser.cpp
+++ b/app/projectbrowser.cpp
@@ -207,7 +207,7 @@ void ProjectBrowser::populateWithNewProject(Forscape::Typeset::Model* model) {
     FileEntry* item = new FileEntry(invisibleRootItem());
     item->setText(0, "untitled");
     item->setIcon(0, main_icon);
-    item->setData(0, Qt::UserRole, QVariant::fromValue(model));
+    item->model = model;
     sortItems(0, Qt::SortOrder::AscendingOrder);
     currently_viewed_file = item;
     setCurrentlyViewed(model);

--- a/app/projectbrowser.cpp
+++ b/app/projectbrowser.cpp
@@ -148,8 +148,7 @@ void ProjectBrowser::saveModel(Forscape::Typeset::Model* saved_model, const std:
     if(create_new_file || rename_file){
         saved_model->path = std_path;
         FileEntry* item = debug_cast<FileEntry*>(entries[std_path]);
-        item->setText(0, toQString(std_path.filename()));
-        item->setData(0, Qt::UserRole, reinterpret_cast<size_t>(saved_model));
+        item->setModel(*saved_model);
         auto result = entries.insert({std_path, item});
         if(!result.second){
             //Saving over existing project file

--- a/app/projectbrowser.cpp
+++ b/app/projectbrowser.cpp
@@ -20,6 +20,7 @@
 //DO THIS: add copy path option
 //DO THIS: import from absolute path is broken (should probably warn)
 //DO THIS: import from folder up is broken
+//DO THIS: start linting
 
 Q_DECLARE_METATYPE(Forscape::Typeset::Model*); //EVENTUALLY: this is only for compability with old versions
 

--- a/app/projectbrowser.cpp
+++ b/app/projectbrowser.cpp
@@ -14,13 +14,12 @@
 #include <QMessageBox>
 #include <QProcess>
 
-//DO THIS: the project view is unintuitive. Allow multiple open projects?
-//DO THIS: need assurance that the viewing history remains valid as files are deleted, renamed, w/e
-//DO THIS: the project browser should probably have an undo stack
-//DO THIS: add copy path option
-//DO THIS: import from absolute path is broken (should probably warn)
-//DO THIS: import from folder up is broken
-//DO THIS: start linting
+//PROJECT BROWSER UPDATE: the project view is unintuitive. Allow multiple open projects?
+//PROJECT BROWSER UPDATE: need assurance that the viewing history remains valid as files are deleted, renamed, w/e
+//PROJECT BROWSER UPDATE: the project browser should probably have an undo stack
+//PROJECT BROWSER UPDATE: add copy path option
+//PROJECT BROWSER UPDATE: import from absolute path is broken (should probably warn)
+//PROJECT BROWSER UPDATE: import from folder up is broken
 
 Q_DECLARE_METATYPE(Forscape::Typeset::Model*); //EVENTUALLY: this is only for compability with old versions
 
@@ -104,6 +103,7 @@ ProjectBrowser::ProjectBrowser(QWidget* parent, MainWindow* main_window)
     setHeaderHidden(true);
     setIndentation(10);
     setMinimumWidth(120);
+    //PROJECT BROWSER UPDATE: should only set this if there are no folders in the project
     setRootIsDecorated(false); //Hide a universal root entry, so the user has the illusion of multiple "top-level" entries
     setContextMenuPolicy(Qt::CustomContextMenu); //Needed to enable context menu
 
@@ -163,7 +163,7 @@ void ProjectBrowser::saveModel(Forscape::Typeset::Model* saved_model, const std:
             QTreeWidgetItem* overwritten = result.first->second;
             //Forscape::Typeset::Model* overwritten_model = getModelForEntry(overwritten);
             //delete overwritten_model;
-            /* DO THIS
+            /* PROJECT BROWSER UPDATE
             modified_files.erase(overwritten_model);
             for(auto& entry : viewing_chain)
                 if(entry.model == overwritten_model)
@@ -270,7 +270,7 @@ void ProjectBrowser::onDeleteFile() {
     main_window->removeFile(item.model);
     item.deleteFile();
 
-    //DO THIS: this has implications for the viewing buffer
+    //PROJECT BROWSER UPDATE: this has implications for the viewing buffer
 
     main_window->reparse();
 }
@@ -350,8 +350,8 @@ void ProjectBrowser::onDirectoryRenamed() {
     }else{
         entry.setPath(new_path);
 
-        //DO THIS: update all the child paths
-        //DO THIS: refactor paths in the code
+        //PROJECT BROWSER UPDATE: update all the child paths
+        //PROJECT BROWSER UPDATE: refactor paths in the code
         //std::string name = toCppString(text);
     }
 }
@@ -383,7 +383,7 @@ void ProjectBrowser::onFileRenamed() {
         entry.setText(0, text);
         entry.path = new_path;
 
-        //DO THIS: update paths in the code
+        //PROJECT BROWSER UPDATE: update paths in the code
     }
 }
 

--- a/app/projectbrowser.h
+++ b/app/projectbrowser.h
@@ -44,7 +44,7 @@ private:
     void linkItemToExistingAncestor(QTreeWidgetItem* item, std::filesystem::path path);
 
     FORSCAPE_UNORDERED_MAP<std::filesystem::path, QTreeWidgetItem*> entries;
-    QTreeWidgetItem* currently_viewed_item; //Used to give affordance
+    FileEntry* currently_viewed_file; //Used to give affordance
     MainWindow* main_window;
 };
 

--- a/app/projectbrowser.h
+++ b/app/projectbrowser.h
@@ -1,0 +1,16 @@
+#ifndef PROJECTBROWSER_H
+#define PROJECTBROWSER_H
+
+#include <filesystem>
+#include <QTreeWidget>
+
+class ProjectBrowser : public QTreeWidget {
+
+public:
+    ProjectBrowser(QWidget* parent = nullptr);
+    void addProject(const std::filesystem::path& entry_point_path);
+    void addFile(const std::filesystem::path& file_path);
+
+};
+
+#endif // PROJECTBROWSER_H

--- a/app/projectbrowser.h
+++ b/app/projectbrowser.h
@@ -2,7 +2,6 @@
 #define PROJECTBROWSER_H
 
 #include <QTreeWidget>
-#include <QApplication>
 #include <filesystem>
 #include <forscape_common.h>
 

--- a/app/projectbrowser.h
+++ b/app/projectbrowser.h
@@ -2,6 +2,7 @@
 #define PROJECTBROWSER_H
 
 #include <QTreeWidget>
+#include <QApplication>
 #include <filesystem>
 #include <forscape_common.h>
 

--- a/app/projectbrowser.h
+++ b/app/projectbrowser.h
@@ -44,7 +44,7 @@ private:
     void linkItemToExistingAncestor(QTreeWidgetItem* item, std::filesystem::path path);
 
     FORSCAPE_UNORDERED_MAP<std::filesystem::path, QTreeWidgetItem*> entries;
-    FileEntry* currently_viewed_file; //Used to give affordance
+    FileEntry* currently_viewed_file = nullptr; //Used to give affordance
     MainWindow* main_window;
 };
 

--- a/app/projectbrowser.h
+++ b/app/projectbrowser.h
@@ -2,15 +2,41 @@
 #define PROJECTBROWSER_H
 
 #include <filesystem>
+#include <forscape_common.h>
 #include <QTreeWidget>
 
+class MainWindow;
+
 class ProjectBrowser : public QTreeWidget {
+    Q_OBJECT
 
 public:
-    ProjectBrowser(QWidget* parent = nullptr);
+    ProjectBrowser(QWidget* parent, MainWindow* main_window);
+    void setProject(Forscape::Typeset::Model* model);
     void addProject(const std::filesystem::path& entry_point_path);
     void addFile(const std::filesystem::path& file_path);
+    void addFile(Forscape::Typeset::Model* model);
+    void saveModel(Forscape::Typeset::Model* saved_model, const std::filesystem::path& std_path);
+    void updateProjectBrowser();
+    void addProjectEntry(Forscape::Typeset::Model* model);
+    void populateWithNewProject(Forscape::Typeset::Model* model);
+    void setCurrentlyViewed(Forscape::Typeset::Model* model);
+    void clear() noexcept;
 
+private slots:
+    void onFileClicked(QTreeWidgetItem* item, int column);
+    void onFileClicked();
+    void onShowInExplorer();
+    void onDeleteFile();
+    void onRightClick(const QPoint& pos);
+
+private:
+    void linkFileToAncestor(QTreeWidgetItem* file_item, const std::filesystem::path file_path);
+    void linkItemToExistingAncestor(QTreeWidgetItem* item, std::filesystem::path path);
+
+    FORSCAPE_UNORDERED_MAP<std::filesystem::path, QTreeWidgetItem*> project_browser_entries;
+    QTreeWidgetItem* currently_viewed_item; //Used to give affordance
+    MainWindow* main_window;
 };
 
 #endif // PROJECTBROWSER_H

--- a/app/projectbrowser.h
+++ b/app/projectbrowser.h
@@ -1,9 +1,9 @@
 #ifndef PROJECTBROWSER_H
 #define PROJECTBROWSER_H
 
+#include <QTreeWidget>
 #include <filesystem>
 #include <forscape_common.h>
-#include <QTreeWidget>
 
 class MainWindow;
 

--- a/app/projectbrowser.h
+++ b/app/projectbrowser.h
@@ -7,6 +7,8 @@
 
 class MainWindow;
 
+namespace Forscape {
+
 class ProjectBrowser : public QTreeWidget {
     Q_OBJECT
 
@@ -29,14 +31,23 @@ private slots:
     void onShowInExplorer();
     void onDeleteFile();
     void onRightClick(const QPoint& pos);
+    void onDirectoryRenamed();
+    void onFileRenamed();
+    void expandDirectory();
 
 private:
-    void linkFileToAncestor(QTreeWidgetItem* file_item, const std::filesystem::path file_path);
+    class FileEntry;
+    class DirectoryEntry;
+    FileEntry& getSelectedFileEntry() const noexcept;
+    DirectoryEntry& getSelectedDirectory() const noexcept;
+    void linkFileToAncestor(FileEntry* file_item, const std::filesystem::path file_path);
     void linkItemToExistingAncestor(QTreeWidgetItem* item, std::filesystem::path path);
 
-    FORSCAPE_UNORDERED_MAP<std::filesystem::path, QTreeWidgetItem*> project_browser_entries;
+    FORSCAPE_UNORDERED_MAP<std::filesystem::path, QTreeWidgetItem*> entries;
     QTreeWidgetItem* currently_viewed_item; //Used to give affordance
     MainWindow* main_window;
 };
+
+}
 
 #endif // PROJECTBROWSER_H

--- a/app/searchdialog.h
+++ b/app/searchdialog.h
@@ -18,7 +18,7 @@ namespace Typeset {
 
 using namespace Forscape;
 
-class SearchDialog : public QDialog{
+class SearchDialog : public QDialog {
     Q_OBJECT
 
 public:

--- a/src/forscape_program.cpp
+++ b/src/forscape_program.cpp
@@ -182,6 +182,11 @@ void Program::getFileSuggestions(std::vector<std::string>& suggestions, std::str
     }
 }
 
+void Program::removeFile(Typeset::Model* model) noexcept {
+    source_files.erase(model->path);
+    all_files.erase(std::remove(all_files.begin(), all_files.end(), model), all_files.end());
+}
+
 Program::ptr_or_code Program::openFromRelativePathSpecifiedExtension(std::filesystem::path rel_path){
     for(const std::filesystem::path& path_entry : project_path){
         std::filesystem::path abs_path = (path_entry / rel_path).lexically_normal();

--- a/src/forscape_program.h
+++ b/src/forscape_program.h
@@ -31,6 +31,7 @@ public:
     void runStaticPass();
     void getFileSuggestions(std::vector<std::string>& suggestions, Typeset::Model* active) const;
     void getFileSuggestions(std::vector<std::string>& suggestions, std::string_view input, Typeset::Model* active) const;
+    void removeFile(Typeset::Model* model) noexcept;
     std::string run();
     void runThread();
     void stop();

--- a/src/forscape_symbol_table.cpp
+++ b/src/forscape_symbol_table.cpp
@@ -78,6 +78,12 @@ void Symbol::getAllOccurences(std::vector<Typeset::Selection>& found) const {
         found.push_back(usage->sel);
 }
 
+void Symbol::getModelOccurences(std::vector<Typeset::Selection>& found, Typeset::Model* model) const {
+    for(SymbolUsage* usage = last_external_usage; usage != nullptr; usage = usage->prevUsage())
+        if(usage->sel.getModel() == model)
+            found.push_back(usage->sel);
+}
+
 SymbolUsage::SymbolUsage() noexcept
     : prev_usage_index(NONE), symbol_index(NONE) {}
 

--- a/src/forscape_symbol_table.h
+++ b/src/forscape_symbol_table.h
@@ -65,6 +65,7 @@ public:
     void getLocalOccurences(std::vector<Typeset::Selection>& found) const;
     void getExternalOccurences(std::vector<Typeset::Selection>& found) const;
     void getAllOccurences(std::vector<Typeset::Selection>& found) const;
+    void getModelOccurences(std::vector<Typeset::Selection>& found, Typeset::Model* model) const;
 };
 
 struct ScopeSegment {

--- a/src/typeset_model.h
+++ b/src/typeset_model.h
@@ -11,10 +11,6 @@
 #include "forscape_parser.h"
 #include "forscape_symbol_lexical_pass.h"
 
-#ifdef QT_VERSION
-class QTreeWidgetItem;
-#endif
-
 namespace Forscape {
 
 namespace Typeset {
@@ -43,7 +39,6 @@ public:
     std::filesystem::path path;
     bool notOnDisk() const noexcept { return path.empty(); }
     #ifdef QT_VERSION
-    QTreeWidgetItem* project_browser_entry  DEBUG_INIT_NULLPTR;
     std::filesystem::file_time_type write_time;
     #endif
     bool is_imported = false;

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -651,7 +651,7 @@ void View::populateHighlightWordsFromParseNode(ParseNode pn){
     else if(parse_tree.getOp(pn) != Code::OP_IDENTIFIER) return;
 
     const Code::Symbol* const sym = parse_tree.getSymbol(pn);
-    if(sym) sym->getAllOccurences(highlighted_words);
+    if(sym) sym->getModelOccurences(highlighted_words, getModel());
 }
 
 bool View::scrolledToBottom() const noexcept {

--- a/src/typeset_view.cpp
+++ b/src/typeset_view.cpp
@@ -1713,19 +1713,14 @@ void Editor::clearTooltip(){
 }
 
 void Editor::rename(){
-    bool ok;
-    QString text = QInputDialog::getText(
-                this,
-                tr("Rename"),
-                tr("New name:"),
-                QLineEdit::Normal,
-                "",
-                &ok
-                );
+    QInputDialog dialog(this);
+    dialog.setWindowFlags(dialog.windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    dialog.setWindowTitle(tr("Rename"));
+    dialog.setLabelText(tr("New name:"));
+    dialog.setInputMode(QInputDialog::InputMode::TextInput);
+    if(dialog.exec() != QDialog::Accepted) return;
 
-    if(!ok) return;
-
-    std::string name = toCppString(text);
+    const std::string name = toCppString(dialog.textValue());
 
     if(isIllFormedUtf8(name)){
         QMessageBox messageBox;

--- a/test/conanfile.txt
+++ b/test/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 eigen/3.4.0
-# gmp/6.2.1
-parallel-hashmap/1.35
+# gmp/6.3.0
+parallel-hashmap/1.37
 readerwriterqueue/1.0.6
 
 [generators]


### PR DESCRIPTION
Redesign and additional features for the project browser pane and document save states.

This MR:
- Separates the project browser pane into its own class
- Add interaction options
  - Hide the project browser
  - Expand/collapse for directories
- Fix unintuitive UX for creating and opening projects (CTRL+N has a dialog for what to create, e.g. Project/File)
- Disables MainWindow context actions to show/hide toolbars, which were inconsistent with custom methods to show/hide toolbars