### PR TITLE
Highlight construct groupings

### DIFF
--- a/src/forscape_symbol_lexical_pass.cpp
+++ b/src/forscape_symbol_lexical_pass.cpp
@@ -201,15 +201,15 @@ void SymbolLexicalPass::resolveAssignment(ParseNode pn) alloc_except {
             break;
 
         case OP_IDENTIFIER:
-            resolveExpr(rhs);
             resolveAssignmentId(pn);
+            resolveExpr(rhs);
             break;
 
         case OP_SUBSCRIPT_ACCESS:
             if(lexical_map.find(parse_tree.getSelection(lhs)) != lexical_map.end()){
                 resolvePotentialIdSub(lhs);
-                resolveExpr(rhs);
                 resolveAssignmentId(pn);
+                resolveExpr(rhs);
             }else{
                 parse_tree.setOp(pn, OP_REASSIGN);
                 resolveAssignmentSubscript(pn, lhs, rhs);

--- a/src/typeset_construct.cpp
+++ b/src/typeset_construct.cpp
@@ -186,6 +186,10 @@ void Construct::paint(Painter& painter) const {
     for(Subphrase* arg : args) arg->paint(painter);
 }
 
+void Construct::paintGrouping(Painter&) const {
+    // DO NOTHING
+}
+
 double Construct::height() const noexcept {
     return above_center + under_center;
 }

--- a/src/typeset_construct.h
+++ b/src/typeset_construct.h
@@ -79,6 +79,7 @@ public:
     virtual void updateSizeFromChildSizes() noexcept = 0;
     void updateLayout() noexcept;
     void paint(Painter& painter) const;
+    virtual void paintGrouping(Painter& painter) const;
     double height() const noexcept;
     double width  DEBUG_INIT_STALE;
     double above_center  DEBUG_INIT_STALE;

--- a/src/typeset_constructs/typeset_big_integral.h
+++ b/src/typeset_constructs/typeset_big_integral.h
@@ -66,6 +66,9 @@ public:
         painter.drawSymbol(x, y, getBigIntegralString(type));
     }
 
+    // EVENTUALLY: it would be nice to highlight groupings for integrals, e.g. in ∫ x ⅆx
+    // treat the '∫' like an opening symbol and ⅆx like a closing one.
+
     static void modifyFirstScript(Construct* con, Controller& c, Subphrase*);
 
     static const std::vector<Construct::ContextAction> actions;

--- a/src/typeset_constructs/typeset_binomial.h
+++ b/src/typeset_constructs/typeset_binomial.h
@@ -63,6 +63,11 @@ public:
         painter.drawSymbol(')', x + width - paren_width, y, paren_width, height());
     }
 
+    virtual void paintGrouping(Painter& painter) const override {
+        painter.drawHighlightedGrouping(x, y, paren_width, height(), "(");
+        painter.drawHighlightedGrouping(x + width - paren_width, y, paren_width, height(), ")");
+    }
+
     virtual bool increasesScriptDepth(uint8_t) const noexcept override{
         return !parent->isLine();
     }

--- a/src/typeset_constructs/typeset_matrix.h
+++ b/src/typeset_constructs/typeset_matrix.h
@@ -149,6 +149,21 @@ public:
         painter.drawLine(x+width-BRACKET_WIDTH-MATRIX_RPADDING, y+BRACKET_VSHIFT+h, BRACKET_WIDTH, 0);
     }
 
+    virtual void paintGrouping(Painter& painter) const override {
+        double h = height();
+        constexpr double m = 2.0;  // margin
+        painter.drawHighlightBox(x+MATRIX_LPADDING-m, y+BRACKET_VSHIFT-m, BRACKET_WIDTH+m, h+2*m);
+        painter.drawHighlightBox(x+width-BRACKET_WIDTH-MATRIX_RPADDING, y+BRACKET_VSHIFT-m, BRACKET_WIDTH+m, h+2*m);
+
+        painter.drawHighlightLine(x+MATRIX_LPADDING, y+BRACKET_VSHIFT, BRACKET_WIDTH, 0);
+        painter.drawHighlightLine(x+MATRIX_LPADDING, y+BRACKET_VSHIFT, 0, h);
+        painter.drawHighlightLine(x+MATRIX_LPADDING, y+BRACKET_VSHIFT+h, BRACKET_WIDTH, 0);
+
+        painter.drawHighlightLine(x+width-BRACKET_WIDTH-MATRIX_RPADDING, y+BRACKET_VSHIFT, BRACKET_WIDTH, 0);
+        painter.drawHighlightLine(x+width-MATRIX_RPADDING, y+BRACKET_VSHIFT, 0, h);
+        painter.drawHighlightLine(x+width-BRACKET_WIDTH-MATRIX_RPADDING, y+BRACKET_VSHIFT+h, BRACKET_WIDTH, 0);
+    }
+
     static std::vector<ContextAction> actions;
 
     virtual const std::vector<ContextAction>& getContextActions(Subphrase* child) const noexcept override {

--- a/src/typeset_model.cpp
+++ b/src/typeset_model.cpp
@@ -575,6 +575,13 @@ void Model::paintGroupings(Painter& painter, const Marker& loc) const {
         Typeset::Marker left = close_lookup->second;
         left.text->paintGrouping(painter, left.index);
     }
+
+    if(loc.atTextEnd())
+        if(Construct* con = loc.text->nextConstructInPhrase())
+            con->paintGrouping(painter);
+    if(loc.atTextStart())
+        if(Construct* con = loc.text->prevConstructInPhrase())
+            con->paintGrouping(painter);
 }
 
 void Model::paintNumberCommas(Painter& painter, double xL, double yT, double xR, double yB, const Selection& sel) const {

--- a/src/typeset_painter.h
+++ b/src/typeset_painter.h
@@ -62,7 +62,11 @@ public:
     void setScriptLevel(uint8_t depth);
     void setOffset(double x, double y);
     void drawText(double x, double y, std::string_view text);
+    void drawHighlightBox(double x, double y, double w, double h);
+    void drawHighlightLine(double x, double y, double w, double h);
+    void drawHighlightText(double x, double y, double w, double h, std::string_view text);
     void drawHighlightedGrouping(double x, double y, double w, std::string_view text);
+    void drawHighlightedGrouping(double x, double y, double w, double h, std::string_view text);
     void drawSymbol(double x, double y, std::string_view text);
     void drawLine(double x, double y, double w, double h);
     void drawDashedLine(double x, double y, double w, double h);


### PR DESCRIPTION
Matrix and binomial constructs have highlighted groupings. It's a silly feature, but moving the cursor next to a matrix seemed inconsistent with the grouping highlightings, and I do like the reactivity.